### PR TITLE
ticket#66 bitbucket - zła kolejność reguł css

### DIFF
--- a/zapisy/site_media/css/common/schedule-courses.css
+++ b/zapisy/site_media/css/common/schedule-courses.css
@@ -2,12 +2,20 @@
  * Style dotyczące osadzenia terminów przedmiotów w komponencie terminarza.
  */
 
+#schedule-legend .pinned,
+.schedule .pinned,
+.schedule .pinned .classroom,
+.schedule .pinned .type
+{
+    background: #EFF0F0 !important;
+}
+
 #schedule-legend .enrolled,
 .schedule .enrolled,
 .schedule .enrolled .classroom,
 .schedule .enrolled .type
 {
-	background: #E0EEEE !important; /* wheat */
+    background: #E0EEEE !important; /* wheat */
 }
 
 #schedule-legend .queued,
@@ -15,14 +23,7 @@
 .schedule .queued .classroom,
 .schedule .queued .type
 {
-	background: #f5e5c4 !important;
-}
-#schedule-legend .pinned,
-.schedule .pinned,
-.schedule .pinned .classroom,
-.schedule .pinned .type
-{
-	background: #EFF0F0 !important;
+    background: #f5e5c4 !important;
 }
 
 .schedule .full


### PR DESCRIPTION
https://bitbucket.org/jablonski/zapisy-uwagi/issues/66/prototyp-planu-pseudo-pull-request

ktoś ładnie zauwazył, zweryfikowałem i ma rację:

sprawa wygląda tak, że jeśli ktoś:
1. najpierw przypiął się do grupy w prototypie planu
2. a potem dodal się do kolejki/od razu do grupy i go wciągneło

to na prototypie planu, box tej grupy miał background-color specyficzny dla 'pinned', mimo że faktycznie był już w grupie/kolejce i powinien mieć inny kolor

powodem była kolejnośc reguł w cssie(css czyta z góry na dół, wszystkie tam mają !important czyli nadpisują się wzajemnie) - .pinned był ostatni, więc nawet jeśli box przyjmował najpierw kolor tła z .enrolled to ostatecznie i tak było to nadpisywane

inna sprawa, ze dołączając do grupy wartoby usunąć ustawienie, że grupa jest przypięta (/records/schedule/prototype/set-pinned)
