### PR TITLE
Issue49 fix

### DIFF
--- a/zapisy/apps/schedule/models/event.py
+++ b/zapisy/apps/schedule/models/event.py
@@ -258,5 +258,4 @@ class Event(models.Model):
         return self.interested.values_list('email', flat=True)
 
     def __unicode__(self):
-        return '{0:s} ({1:s})'.format(smart_unicode(self.title),
-                                      smart_unicode(self.description))
+        return u'%s %s' % (self.title, self.description)

--- a/zapisy/apps/schedule/tests/testing_models.py
+++ b/zapisy/apps/schedule/tests/testing_models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.test import TestCase
 from zapisy.apps.schedule.models import SpecialReservation, Event, Term as EventTerm
 from apps.enrollment.courses.models import Semester, Classroom, Term
@@ -118,8 +119,8 @@ class EventTestCase(TestCase):
 
         teacher = User.objects.all()[0]
         event = Event(
-            title='an event',
-            description='an event',
+            title='Żółta żaba żarła żur',
+            description='ąęńółść',
             type=Event.TYPE_GENERIC,
             status=Event.STATUS_ACCEPTED,
             author=teacher,
@@ -173,3 +174,8 @@ class EventTestCase(TestCase):
         event.delete()
         terms = EventTerm.objects.all()
         self.assertFalse(terms)
+
+    def test_event_unicode_method(self):
+        events = Event.objects.all()
+        for event in events:
+            unicode(event)


### PR DESCRIPTION
Poprawka metody unicode dla wydarzeń z polskimi znakami w nazwie. Naprawia #49 
