### PR TITLE
issue #73: freedays are now sorted

### DIFF
--- a/zapisy/apps/enrollment/courses/admin/admin.py
+++ b/zapisy/apps/enrollment/courses/admin/admin.py
@@ -109,6 +109,10 @@ class SemesterAdmin(admin.ModelAdmin):
     ]
     list_editable = ('visible',)
 
+class FreedayAdmin(admin.ModelAdmin):
+    # todo: add filter with academic_year with newer django
+    ordering = ('-day',)
+
 class CourseInline(admin.TabularInline):
     model = Course
 
@@ -396,7 +400,7 @@ admin.site.register(Tag)
 admin.site.register(Effects)
 admin.site.register(Classroom, ClassroomAdmin)
 admin.site.register(Semester, SemesterAdmin)
-admin.site.register(Freeday)
+admin.site.register(Freeday, FreedayAdmin)
 admin.site.register(ChangedDay)
 admin.site.register(Type, TypeAdmin)
 admin.site.register(PointTypes)

--- a/zapisy/apps/enrollment/courses/models/semester.py
+++ b/zapisy/apps/enrollment/courses/models/semester.py
@@ -314,4 +314,3 @@ class ChangedDay(models.Model):
         verbose_name = 'dzień zmienony na inny'
         verbose_name_plural = 'dni zmienione na inne'
         app_label = 'courses'
-


### PR DESCRIPTION
Tried to add filter with academic year, but didn't succeed (mostly because of this old django version).