### PR TITLE
[News] Fixed 'none' in news search field

### DIFF
--- a/zapisy/templates/news/list_all.html
+++ b/zapisy/templates/news/list_all.html
@@ -27,11 +27,7 @@ u
     <div id="od-news-top-bar" class="main-top-bar">
         <form id="od-news-search-form" method="get">
             <div class="main-filter-input">
-                {% if query %}
-                    <input class="text" type="text" name="q" id="od-news-search-q" value="{{ query|lower }}" placeholder="Szukaj w tytułach i treści..."/>
-                {% else %}
-                    <input class="text" type="text" name="q" id="od-news-search-q" placeholder="Szukaj w tytułach i treści..."/>
-                {% endif %}
+                <input class="text" type="text" name="q" id="od-news-search-q" value="{{ query|default_if_none:''|lower }}" placeholder="Szukaj w tytułach i treści..."/>
                 <input class="reset" type="reset" id="od-news-search-reset" value="X"/>
             </div>
         </form>


### PR DESCRIPTION
Fixes #189 
Po wejściu w aktualności bez wyszukania czegokolwiek zapisy serwują coś takiego 
![none_in_news](https://user-images.githubusercontent.com/18621228/31728841-b265ad24-b42d-11e7-8ff2-0b3412a87339.png)
zamiast placeholdera