### PR TITLE
Fix #253

### DIFF
--- a/zapisy/apps/schedule/models/term.py
+++ b/zapisy/apps/schedule/models/term.py
@@ -86,7 +86,7 @@ class Term(models.Model):
         if self.room:
             if not self.room.can_reserve:
                 raise ValidationError(
-                    message={'classroom': [u'Ta sala nie jest przeznaczona do rezerwacji']},
+                    message={'room': [u'Ta sala nie jest przeznaczona do rezerwacji']},
                     code='invalid'
                 )
 


### PR DESCRIPTION
Problem powodowany był przez to, że term.py class_room ma jako room i error nie miał gdzie być przypisany.