### PR TITLE
Fix #232

### DIFF
--- a/zapisy/apps/schedule/views.py
+++ b/zapisy/apps/schedule/views.py
@@ -93,6 +93,7 @@ def edit_event(request, event_id=None):
 
             messages.success(request, u'Zmieniono zdarzenie')
             return redirect(event)
+    errors = True
 
     return TemplateResponse(request, 'schedule/reservation.html', locals())
 


### PR DESCRIPTION
Fixes #232 

Opis:
Okazuje się, że wyświetlenie opcji ignorowania konfliktu zależy od zmiennej errors, która nie była nigdy ustawiana przy edycji... 