### PR TITLE
Naprawa context processors w 1.10

### DIFF
--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -138,7 +138,7 @@ TEMPLATES = [
             'context_processors': [
                 'django.contrib.messages.context_processors.messages',
                 'django.contrib.auth.context_processors.auth',
-                "django.template.context_processors.request",
+                'django.template.context_processors.request',
             ],
             'loaders': [
                 ('django.template.loaders.cached.Loader', [


### PR DESCRIPTION
Przy upgradzie do 1.10 zaginęły stare ustawienia context_processors, szczególnie `request`. To spowodowało problem 60 na trackerze (wszystkie linijki typu `if request.user.is_staff/admin` zawsze były false)