### PR TITLE
Wysyłanie maili w django 1.10

### DIFF
--- a/zapisy/mailer/management/commands/retry_deferred.py
+++ b/zapisy/mailer/management/commands/retry_deferred.py
@@ -1,13 +1,13 @@
 import logging
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from mailer.models import Message
 
 logger = logging.getLogger('mailer.retry_deferred')
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Attempt to resend any deferred mail.'
     
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         logger.info("-" * 72)        
         count = Message.objects.retry_deferred() # @@@ new_priority not yet supported
         logger.info("%s message(s) retried" % count)

--- a/zapisy/mailer/management/commands/send_mail.py
+++ b/zapisy/mailer/management/commands/send_mail.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from mailer.engine import send_all
 
@@ -10,10 +10,10 @@ logger = logging.getLogger('mailer.send_mail')
 # allow a sysadmin to pause the sending of mail temporarily.
 PAUSE_SEND = getattr(settings, "MAILER_PAUSE_SEND", False)
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Do one pass through the mail queue, attempting to send all mail.'
     
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         logger.info("-" * 72)
         # if PAUSE_SEND is turned on don't do anything.
         if not PAUSE_SEND:


### PR DESCRIPTION
Przy upgradzie do Django 1.10 nie został poprawiony kod wysyłający maile, który korzystał z usuniętej w 1.10 klasy do integracji z manage.py.