### PR TITLE
Usunięcie zduplikowanej informacji w ocenie zajęć w "Moje konto"

### DIFF
--- a/zapisy/apps/users/templates/users/my_profile.html
+++ b/zapisy/apps/users/templates/users/my_profile.html
@@ -135,18 +135,6 @@ $('.checkall').live('click', function(){
      </table>
 {% endif %}
 
-{% if grade %}
-    <h4>Udział w Ocenie zajęć</h4>
-    <table class="table-info-big">
-            {% for semester in grade %}
-
-        <tr>
-            <td>{{ semester }}</td>
-        </tr>
-            {% endfor %}
-    </table>
-{% endif %}
-
 <p class="info-table-header">Terminy</p>
 <table class="table-info-big">
     {% with dateFormatStr="l j E G:i" %}


### PR DESCRIPTION
https://gyazo.com/a012ea215be9765e64f5c7458be4f691
Wersja na dole jest poprawna (widać, bo używa nowego, ciemniejszego formatowania). Ta wersja na górze powinna była zostać usunięta przy tych zmianach.