### PR TITLE
Używaj imienia i nazwiska jako autora emaila

### DIFF
--- a/zapisy/apps/notifications/templates/notifications/send-news.html
+++ b/zapisy/apps/notifications/templates/notifications/send-news.html
@@ -3,5 +3,5 @@
 {% block content %}
 {{ body|safe }}
 
-{{ author }} 
+{{ author.get_full_name }} 
 {% endblock %}


### PR DESCRIPTION
W tej chwili emaile podpisywane są username'ami:

> Cześć Jakub,
> 
> ....
> 
> mlewandowski 

Wystarczy zmienić jeden template by używać imion i nazwisk.