### PR TITLE
Naprawa "wstecz" w asynchronicznych stronach przedmiotów

### DIFF
--- a/zapisy/apps/enrollment/courses/assets/ajaxCourseLoad.ts
+++ b/zapisy/apps/enrollment/courses/assets/ajaxCourseLoad.ts
@@ -139,6 +139,7 @@ function onPopState(event : PopStateEvent) {
 	if (event.state) {
 		populateCoursePageFromCourseInfo(event.state);
 	} else {
+		// See https://stackoverflow.com/questions/2405117/difference-between-window-location-href-window-location-href-and-window-location
 		window.location.href = window.location.href;
 	}
 }


### PR DESCRIPTION
Naciśnięcie przycisku "wstecz" na asynchronicznie załadowanej liście przedmiotów obecnie niczym nie skutkuje, bo brakuje odpowiedniego event handlera.