### PR TITLE
Fix remove_student_from_queue

### DIFF
--- a/zapisy/apps/enrollment/records/models.py
+++ b/zapisy/apps/enrollment/records/models.py
@@ -394,7 +394,8 @@ class Queue(models.Model):
         try:
             student = Student.objects.select_related('user').get(user__id=user_id)
 
-            record = Queue.queued.select_related('group').get(group__id=group_id, student=student)
+            record = Queue.queued.select_related('group').get(
+                group__id=group_id, student=student, deleted=False)
             group = record.group
             record.delete()
             logger.info('User %s <id: %s> is now removed from queue of group "%s" <id: %s>' % (student.user.username, student.user.id, group, group.id))


### PR DESCRIPTION
`remove_student_from_queue` powinna spróbować usunąć obiekt `Queue` który odpowiada wpisowi studenta w kolejce i rzucić `AlreadyNotAssigned`, jeżeli takiego wpisu nie ma. Jednakże mamy dwie sytuacje, w których może go "nie być":
1) Fizycznie nie ma takiego wpisu w bazie
2) Wpis jest, ale ma ustawione pole `deleted` na `True` (niekonsekwencja i spaghetti w kodzie który te wpisy modifykuje)

Rzeczona funkcja nie obsługiwała drugiego przypadku, więc czasem próbowała usunąć z grupy nieistniejących w niej studentów (których obiekt `Queue` miał `deleted`==`True`) i ustawiała licznik grupy na < 0.