### PR TITLE
Bugfix: DB dumps were not anonymized

### DIFF
--- a/db_backups/perform_dump.sh
+++ b/db_backups/perform_dump.sh
@@ -63,7 +63,7 @@ run_script_on_temp_db "$TEMP_DUMP_PATH_PROD"
 # Then anonymize
 run_script_on_temp_db anonymize.sql
 # Finally dump
-dump_db_to_file "$II_ZAPISY_DB_BACKUP_DB_NAME" "$TEMP_DUMP_PATH_DEV"
+dump_db_to_file "$TEMP_DB_NAME" "$TEMP_DUMP_PATH_DEV"
 # Get rid of the temp db
 teardown_temp_db
 

--- a/db_backups/slack_notifications.py
+++ b/db_backups/slack_notifications.py
@@ -23,5 +23,5 @@ def send_success_notification(slack_client, dev_db_link: str, seconds_elapsed: i
     _send_slack_msg(slack_client, msg)
 
 def send_error_notification(slack_client, error_msg: str):
-    msg = f'*Failed to back up databases:* ```{error_msg}```'
+    msg = f'*Failed to back up databases:*n\```{error_msg}```'
     _send_slack_msg(slack_client, msg)


### PR DESCRIPTION
W skrypcie perform_dump.sh był błąd, który powodował, że ostatecznie dumpy devowe i produkcyjne były takie same (niezanonimizowane)