### PR TITLE
CircleCI fixes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,14 +9,13 @@ machine:
 
 dependencies:
   override:
+    # Make sure we're operating on a clean repo
+    - git clean -f && git clean -fd
     - pip --version
     - pip install -U setuptools
     - pip install --upgrade pip
     - pip install -r requirements.test.txt
     - npm i -g npm  # Make sure we're using the latest npm version
-    # Remove folders that might have been left over from previous commands
-    # and that would cause problems
-    - rm -rf /home/ubuntu/.yarn/ && rm -rf node_modules
     - npm --version
     - npm root -g
     - npm i -g yarn


### PR DESCRIPTION
CircleCI wydaje się nie czyścić build directory przed kompilacją, przez co zmiany z mojego innego brancha na którym podbiłem webpacka do 4 popsuły buildy master-deva i pochodnych. Ten PR czyści build dira przed buildem