### PR TITLE
Fixy node.js'owe dla CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,9 @@ dependencies:
     # branches
     # It seems you can't disable this, see https://discuss.circleci.com/t/how-to-always-rebuild-without-npm-cache/1196
     - rm -rf node_modules/
+    # For good measure also clear any other crap they might have restored from the cache
+    - git clean -nd
+    - git clean -fd
     - pip --version
     - pip install -U setuptools
     - pip install --upgrade pip


### PR DESCRIPTION
Ktoś z CircleCI wpadł na mądry pomysł cache'owania node_modules, co może psuć nasze buildy, bo pomiędzy różnymi branchami mamy różne wersje tych samych paczek; ponieważ nie ma oficjalnego sposobu na wyłączenie tego, po prostu czyścimy node_modules przy starcie (https://discuss.circleci.com/t/how-to-always-rebuild-without-npm-cache/1196).