### PR TITLE
Students votes api

### DIFF
--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -59,9 +59,10 @@ class SpecialReservationSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-"""Serialize single student vote
-Get proper vote value, course name and student id"""
 class SingleVoteSerializer(serializers.ModelSerializer):
+    """Serialize single student vote
+    Get proper vote value, course name and student id"""
+
     vote_points = serializers.SerializerMethodField()
     course_name = serializers.CharField(source='entity.name')
 
@@ -73,8 +74,9 @@ class SingleVoteSerializer(serializers.ModelSerializer):
         fields = ('student', 'course_name', 'vote_points')
 
 
-"""Serialize vote system state, get id and friendly name"""
 class SystemStateSerializer(serializers.ModelSerializer):
+    """Serialize vote system state, get id and friendly name"""
+    
     state_name = serializers.SerializerMethodField()
 
     def get_state_name(self, systemstate_model):

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -72,6 +72,11 @@ class SingleVoteSerializer(serializers.ModelSerializer):
 
 
 class SystemStateSerializer(serializers.ModelSerializer):
+    state_name = serializers.SerializerMethodField()
+    
+    def get_state_name(self, systemstate_model):
+        return str(systemstate_model)
+        
     class Meta:
         model = SystemState
-        fields = ('id', 'year')
+        fields = ('id', 'name')

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -68,8 +68,8 @@ class SingleVoteSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = SingleVote
-        fields =  ('student', 'course_name', 'vote_points')
-        
+        fields = ('student', 'course_name', 'vote_points')
+
 
 class SystemStateSerializer(serializers.ModelSerializer):
     class Meta:

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -73,10 +73,10 @@ class SingleVoteSerializer(serializers.ModelSerializer):
 
 class SystemStateSerializer(serializers.ModelSerializer):
     state_name = serializers.SerializerMethodField()
-    
+
     def get_state_name(self, systemstate_model):
         return str(systemstate_model)
-        
+
     class Meta:
         model = SystemState
         fields = ('id', 'state_name')

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -68,7 +68,7 @@ class SingleVoteSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = SingleVote
-        fields =  ('student', 'entity', 'course', 'course_name', 'vote_points')
+        fields =  ('student', 'course_name', 'vote_points')
         
 
 class SystemStateSerializer(serializers.ModelSerializer):

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 from apps.enrollment.courses.models.classroom import Classroom
 from apps.enrollment.courses.models.semester import Semester
 from apps.offer.desiderata.models import Desiderata, DesiderataOther
-from apps.offer.vote.models import SystemState
+from apps.offer.vote.models import SingleVote, SystemState
 from apps.schedule.models.specialreservation import SpecialReservation
 from apps.users.models import Employee
 
@@ -57,6 +57,13 @@ class SpecialReservationSerializer(serializers.ModelSerializer):
     class Meta:
         model = SpecialReservation
         fields = '__all__'
+
+
+class SingleVoteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SingleVote
+        fields =  ('value', 'correction', 'student', 'entity', 'course')
+        
 
 class SystemStateSerializer(serializers.ModelSerializer):
     class Meta:

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -59,6 +59,8 @@ class SpecialReservationSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+"""Serialize single student vote
+Get proper vote value, course name and student id"""
 class SingleVoteSerializer(serializers.ModelSerializer):
     vote_points = serializers.SerializerMethodField()
     course_name = serializers.CharField(source='entity.name')
@@ -71,6 +73,7 @@ class SingleVoteSerializer(serializers.ModelSerializer):
         fields = ('student', 'course_name', 'vote_points')
 
 
+"""Serialize vote system state, get id and friendly name"""
 class SystemStateSerializer(serializers.ModelSerializer):
     state_name = serializers.SerializerMethodField()
 

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -79,4 +79,4 @@ class SystemStateSerializer(serializers.ModelSerializer):
         
     class Meta:
         model = SystemState
-        fields = ('id', 'name')
+        fields = ('id', 'state_name')

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -60,12 +60,18 @@ class SpecialReservationSerializer(serializers.ModelSerializer):
 
 
 class SingleVoteSerializer(serializers.ModelSerializer):
+    vote_points = serializers.SerializerMethodField()
+    course_name = serializers.CharField(source='entity.name')
+
+    def get_vote_points(self, vote_model):
+        return max(vote_model.value, vote_model.correction)
+
     class Meta:
         model = SingleVote
-        fields =  ('value', 'correction', 'student', 'entity', 'course')
+        fields =  ('student', 'entity', 'course', 'course_name', 'vote_points')
         
 
 class SystemStateSerializer(serializers.ModelSerializer):
     class Meta:
         model = SystemState
-        fields = '__all__'
+        fields = ('id', 'year')

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -76,7 +76,7 @@ class SingleVoteSerializer(serializers.ModelSerializer):
 
 class SystemStateSerializer(serializers.ModelSerializer):
     """Serialize vote system state, get id and friendly name"""
-    
+
     state_name = serializers.SerializerMethodField()
 
     def get_state_name(self, systemstate_model):

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -60,13 +60,15 @@ class SpecialReservationSerializer(serializers.ModelSerializer):
 
 
 class SingleVoteSerializer(serializers.ModelSerializer):
-    """Serialize single student vote
-    Get proper vote value, course name and student id"""
+    """Serializes single student vote.
 
+    Gets correct vote value, course name and student id.
+    """
     vote_points = serializers.SerializerMethodField()
     course_name = serializers.CharField(source='entity.name')
 
     def get_vote_points(self, vote_model):
+        """Getter function for vote_points field."""
         return max(vote_model.value, vote_model.correction)
 
     class Meta:
@@ -75,11 +77,11 @@ class SingleVoteSerializer(serializers.ModelSerializer):
 
 
 class SystemStateSerializer(serializers.ModelSerializer):
-    """Serialize vote system state, get id and friendly name"""
-
+    """Serializes vote system state, get id and friendly name"""
     state_name = serializers.SerializerMethodField()
 
     def get_state_name(self, systemstate_model):
+        """Getter function for system state_name field."""
         return str(systemstate_model)
 
     class Meta:

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from apps.enrollment.courses.models.classroom import Classroom
 from apps.enrollment.courses.models.semester import Semester
 from apps.offer.desiderata.models import Desiderata, DesiderataOther
+from apps.offer.vote.models import SystemState
 from apps.schedule.models.specialreservation import SpecialReservation
 from apps.users.models import Employee
 
@@ -55,4 +56,9 @@ class DesiderataOtherSerializer(serializers.ModelSerializer):
 class SpecialReservationSerializer(serializers.ModelSerializer):
     class Meta:
         model = SpecialReservation
+        fields = '__all__'
+
+class SystemStateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SystemState
         fields = '__all__'

--- a/zapisy/apps/api/rest/v1/tests/test_api.py
+++ b/zapisy/apps/api/rest/v1/tests/test_api.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from apps.offer.vote.models import SystemState, SingleVote
+from apps.api.rest.v1.views import SingleVoteViewSet, SystemStateViewSet
+
+class VoteTests(TestCase):
+    def setUp(self):
+        state = SystemState(year=2010) #id:1
+        state.save()
+        state = SystemState(year=2018) #id:2
+        state.save()
+
+    def test_system_states_endpoint(self):
+        client = APIClient()
+        response = client.get('/api/v1/systemstate/')
+        self.assertEqual(response.status_code, 200)
+        resp_json = json.loads(json.dumps(response.data))
+        self.assertEqual(len(resp_json), 2)
+        self.assertEqual(resp_json[0], {"id": 1, "state_name": "Ustawienia systemu na rok 2010"})
+        self.assertEqual(resp_json[1], {"id": 2, "state_name": "Ustawienia systemu na rok 2018"})
+
+    def test_votes_endpoint(self):
+        client = APIClient()
+        response = client.get('/api/v1/votes/', params=(('state', 1)))
+        self.assertEqual(response.status_code, 200)

--- a/zapisy/apps/api/rest/v1/tests/test_api.py
+++ b/zapisy/apps/api/rest/v1/tests/test_api.py
@@ -1,3 +1,5 @@
+import json
+
 from django.test import TestCase
 from rest_framework.test import APIClient
 
@@ -6,6 +8,7 @@ from apps.api.rest.v1.views import SingleVoteViewSet, SystemStateViewSet
 
 
 class VoteSystemTests(TestCase):
+
     def setUp(self):
         state = SystemState(year=2010)
         state.save()
@@ -27,13 +30,11 @@ class VoteSystemTests(TestCase):
         self.assertEqual(resp_json[0], {"id": 1, "state_name": "Ustawienia systemu na rok 2010"})
         self.assertEqual(resp_json[1], {"id": 2, "state_name": "Ustawienia systemu na rok 2018"})
 
-    
     def test_votes_endpoint(self):
-        """Test votes endpoint,
+        """Tests votes endpoint with empty data.
 
-        There are no votes in test database, only check if resource was found
+        There are no votes in test database, only checks if resource was found.
         """
-
         client = APIClient()
         response = client.get('/api/v1/votes/', params=(('state', 1)))
         self.assertEqual(response.status_code, 200)

--- a/zapisy/apps/api/rest/v1/tests/test_api.py
+++ b/zapisy/apps/api/rest/v1/tests/test_api.py
@@ -4,13 +4,16 @@ from rest_framework.test import APIClient
 from apps.offer.vote.models import SystemState, SingleVote
 from apps.api.rest.v1.views import SingleVoteViewSet, SystemStateViewSet
 
-class VoteTests(TestCase):
+
+class VoteSystemTests(TestCase):
     def setUp(self):
-        state = SystemState(year=2010) #id:1
+        state = SystemState(year=2010)
         state.save()
-        state = SystemState(year=2018) #id:2
+        state = SystemState(year=2018)
         state.save()
 
+    """Get system states (there was none, so we get only states from setUp)
+    Check if content is JSON and contains expected data"""
     def test_system_states_endpoint(self):
         client = APIClient()
         response = client.get('/api/v1/systemstate/')
@@ -20,6 +23,8 @@ class VoteTests(TestCase):
         self.assertEqual(resp_json[0], {"id": 1, "state_name": "Ustawienia systemu na rok 2010"})
         self.assertEqual(resp_json[1], {"id": 2, "state_name": "Ustawienia systemu na rok 2018"})
 
+    """Test votes endpoint, there are no votes in test database,
+    only check if resource was found"""
     def test_votes_endpoint(self):
         client = APIClient()
         response = client.get('/api/v1/votes/', params=(('state', 1)))

--- a/zapisy/apps/api/rest/v1/tests/test_api.py
+++ b/zapisy/apps/api/rest/v1/tests/test_api.py
@@ -12,12 +12,12 @@ class VoteSystemTests(TestCase):
         state = SystemState(year=2018)
         state.save()
 
-    """Get system states (there was none, so we get only states from setUp)
-    Check if content is JSON and contains expected data"""
     def test_system_states_endpoint(self):
         """Tests system state api.
-        
+
         Queries the api with two SystemState instances using HTTP client.
+        Check if content is JSON and contains expected data.
+        There were no states in db, so we get only states created in setUp
         """
         client = APIClient()
         response = client.get('/api/v1/systemstate/')
@@ -27,9 +27,13 @@ class VoteSystemTests(TestCase):
         self.assertEqual(resp_json[0], {"id": 1, "state_name": "Ustawienia systemu na rok 2010"})
         self.assertEqual(resp_json[1], {"id": 2, "state_name": "Ustawienia systemu na rok 2018"})
 
-    """Test votes endpoint, there are no votes in test database,
-    only check if resource was found"""
+    
     def test_votes_endpoint(self):
+        """Test votes endpoint,
+
+        There are no votes in test database, only check if resource was found
+        """
+
         client = APIClient()
         response = client.get('/api/v1/votes/', params=(('state', 1)))
         self.assertEqual(response.status_code, 200)

--- a/zapisy/apps/api/rest/v1/tests/test_api.py
+++ b/zapisy/apps/api/rest/v1/tests/test_api.py
@@ -3,17 +3,34 @@ import json
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from apps.offer.vote.models import SystemState, SingleVote
 from apps.api.rest.v1.views import SingleVoteViewSet, SystemStateViewSet
+from apps.enrollment.courses.tests.factories import CourseEntityFactory
+from apps.offer.vote.models import SystemState, SingleVote
+from apps.users.tests.factories import StudentFactory
 
 
 class VoteSystemTests(TestCase):
 
     def setUp(self):
-        state = SystemState(year=2010)
-        state.save()
-        state = SystemState(year=2018)
-        state.save()
+        state1 = SystemState(year=2010)
+        state1.save()
+        state2 = SystemState(year=2018)
+        state2.save()
+        students = [StudentFactory(), StudentFactory()]
+        courses = [CourseEntityFactory(name="Pranie"), CourseEntityFactory(name="Zmywanie")]
+        SingleVote.objects.bulk_create([
+            SingleVote(state=state1, student=students[0], entity=courses[0], value=2),
+            SingleVote(state=state1, student=students[1], entity=courses[0], value=0),
+            SingleVote(state=state1, student=students[0], entity=courses[1], value=3),
+            SingleVote(state=state1, student=students[1], entity=courses[1], value=1),
+            SingleVote(state=state2, student=students[0], entity=courses[0], value=0),
+            SingleVote(state=state2, student=students[1], entity=courses[0], value=0, correction=1),
+            SingleVote(state=state2, student=students[0], entity=courses[1], value=3),
+            SingleVote(state=state2, student=students[1], entity=courses[1], value=1, correction=2),
+        ])
+        self.state1 = state1
+        self.state2 = state2
+        self.students = students
 
     def test_system_states_endpoint(self):
         """Tests system state api.
@@ -31,10 +48,27 @@ class VoteSystemTests(TestCase):
         self.assertEqual(resp_json[1], {"id": 2, "state_name": "Ustawienia systemu na rok 2018"})
 
     def test_votes_endpoint(self):
-        """Tests votes endpoint with empty data.
+        """Tests votes endpoint.
 
-        There are no votes in test database, only checks if resource was found.
+        Checks, that only votes with value in a requested System State are
+        returned and their values are computed correctly.
         """
         client = APIClient()
-        response = client.get('/api/v1/votes/', params=(('state', 1)))
+        response = client.get('/api/v1/votes/', {'state': self.state2.pk}, format='json')
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 3)
+        self.assertDictEqual(response.data[0], {
+            'student': self.students[1].pk,
+            'course_name': "Pranie",
+            'vote_points': 1
+        })
+        self.assertDictEqual(response.data[1], {
+            'student': self.students[0].pk,
+            'course_name': "Zmywanie",
+            'vote_points': 3
+        })
+        self.assertDictEqual(response.data[2], {
+            'student': self.students[1].pk,
+            'course_name': "Zmywanie",
+            'vote_points': 2
+        })

--- a/zapisy/apps/api/rest/v1/tests/test_api.py
+++ b/zapisy/apps/api/rest/v1/tests/test_api.py
@@ -6,7 +6,7 @@ from rest_framework.test import APIClient
 from apps.api.rest.v1.views import SingleVoteViewSet, SystemStateViewSet
 from apps.enrollment.courses.tests.factories import CourseEntityFactory
 from apps.offer.vote.models import SystemState, SingleVote
-from apps.users.tests.factories import StudentFactory
+from apps.users.tests.factories import StudentFactory, UserFactory
 
 
 class VoteSystemTests(TestCase):
@@ -31,6 +31,7 @@ class VoteSystemTests(TestCase):
         self.state1 = state1
         self.state2 = state2
         self.students = students
+        self.staff_member = UserFactory(is_staff=True)
 
     def test_system_states_endpoint(self):
         """Tests system state api.
@@ -40,6 +41,7 @@ class VoteSystemTests(TestCase):
         There were no states in db, so we get only states created in setUp
         """
         client = APIClient()
+        client.force_authenticate(user=self.staff_member)
         response = client.get('/api/v1/systemstate/')
         self.assertEqual(response.status_code, 200)
         resp_json = json.loads(json.dumps(response.data))
@@ -54,6 +56,7 @@ class VoteSystemTests(TestCase):
         returned and their values are computed correctly.
         """
         client = APIClient()
+        client.force_authenticate(user=self.staff_member)
         response = client.get('/api/v1/votes/', {'state': self.state2.pk}, format='json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 3)

--- a/zapisy/apps/api/rest/v1/tests/test_api.py
+++ b/zapisy/apps/api/rest/v1/tests/test_api.py
@@ -15,6 +15,10 @@ class VoteSystemTests(TestCase):
     """Get system states (there was none, so we get only states from setUp)
     Check if content is JSON and contains expected data"""
     def test_system_states_endpoint(self):
+        """Tests system state api.
+        
+        Queries the api with two SystemState instances using HTTP client.
+        """
         client = APIClient()
         response = client.get('/api/v1/systemstate/')
         self.assertEqual(response.status_code, 200)

--- a/zapisy/apps/api/rest/v1/urls.py
+++ b/zapisy/apps/api/rest/v1/urls.py
@@ -2,7 +2,7 @@ from rest_framework import routers
 
 from .views import (ClassroomViewSet, DesiderataOtherViewSet,
                     DesiderataViewSet, EmployeeViewSet, SemesterViewSet,
-                    SpecialReservationViewSet)
+                    SpecialReservationViewSet, SystemStateViewSet)
 
 router = routers.DefaultRouter()
 router.register(r'semesters', SemesterViewSet)
@@ -11,3 +11,4 @@ router.register(r'employees', EmployeeViewSet)
 router.register(r'desideratas', DesiderataViewSet)
 router.register(r'desiderata-others', DesiderataOtherViewSet)
 router.register(r'special-reservation', SpecialReservationViewSet)
+router.register(r'systemstate', SystemStateViewSet)

--- a/zapisy/apps/api/rest/v1/urls.py
+++ b/zapisy/apps/api/rest/v1/urls.py
@@ -2,7 +2,8 @@ from rest_framework import routers
 
 from .views import (ClassroomViewSet, DesiderataOtherViewSet,
                     DesiderataViewSet, EmployeeViewSet, SemesterViewSet,
-                    SpecialReservationViewSet, SystemStateViewSet)
+                    SpecialReservationViewSet, SystemStateViewSet,
+                    SingleVoteViewSet)
 
 router = routers.DefaultRouter()
 router.register(r'semesters', SemesterViewSet)
@@ -12,3 +13,4 @@ router.register(r'desideratas', DesiderataViewSet)
 router.register(r'desiderata-others', DesiderataOtherViewSet)
 router.register(r'special-reservation', SpecialReservationViewSet)
 router.register(r'systemstate', SystemStateViewSet)
+router.register(r'votes', SingleVoteViewSet, 'Votes')

--- a/zapisy/apps/api/rest/v1/views.py
+++ b/zapisy/apps/api/rest/v1/views.py
@@ -61,7 +61,7 @@ class SpecialReservationViewSet(viewsets.ModelViewSet):
 class SingleVoteViewSet(viewsets.ModelViewSet):
     """Return votes by selected state (or all votes otherwise)
     Skip votes with no value for clarity"""
-    
+
     http_method_names = ['get']
     serializer_class = SingleVoteSerializer
     filter_fields = '__all__'
@@ -73,7 +73,6 @@ class SingleVoteViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(state_id=system_state_id).exclude(value=0, correction=0)
 
         return queryset
-
 
 
 class SystemStateViewSet(viewsets.ModelViewSet):

--- a/zapisy/apps/api/rest/v1/views.py
+++ b/zapisy/apps/api/rest/v1/views.py
@@ -5,7 +5,7 @@ from rest_framework.authentication import (BasicAuthentication,
 from apps.enrollment.courses.models.classroom import Classroom
 from apps.enrollment.courses.models.semester import Semester
 from apps.offer.desiderata.models import Desiderata, DesiderataOther
-from apps.offer.vote.models import SystemState
+from apps.offer.vote.models import SystemState, SingleVote
 from apps.schedule.models.specialreservation import SpecialReservation
 from apps.users.models import Employee
 from apps.users.utils import StaffPermission
@@ -13,7 +13,7 @@ from apps.users.utils import StaffPermission
 from .serializers import (ClassroomSerializer, DesiderataOtherSerializer,
                           DesiderataSerializer, EmployeeSerializer,
                           SemesterSerializer, SpecialReservationSerializer,
-                          SystemStateSerializer)
+                          SingleVoteSerializer, SystemStateSerializer)
 
 
 class SemesterViewSet(viewsets.ModelViewSet):
@@ -56,6 +56,21 @@ class SpecialReservationViewSet(viewsets.ModelViewSet):
     queryset = SpecialReservation.objects.all()
     serializer_class = SpecialReservationSerializer
     filter_fields = '__all__'
+
+
+class SingleVoteViewSet(viewsets.ModelViewSet):
+    http_method_names = ['get']
+    serializer_class = SingleVoteSerializer
+    filter_fields = '__all__'
+
+    def get_queryset(self):
+        queryset = SingleVote.objects.all()
+        system_state_id = self.request.GET.get('state')
+        if system_state_id:
+            queryset = queryset.filter(state_id=system_state_id).exclude(value=0, correction=0)
+
+        return queryset
+
 
 class SystemStateViewSet(viewsets.ModelViewSet):
     http_method_names = ['get']

--- a/zapisy/apps/api/rest/v1/views.py
+++ b/zapisy/apps/api/rest/v1/views.py
@@ -58,6 +58,8 @@ class SpecialReservationViewSet(viewsets.ModelViewSet):
     filter_fields = '__all__'
 
 
+"""Return votes by selected state (or all votes otherwise)
+Skip votes with no value for clarity"""
 class SingleVoteViewSet(viewsets.ModelViewSet):
     http_method_names = ['get']
     serializer_class = SingleVoteSerializer
@@ -72,6 +74,7 @@ class SingleVoteViewSet(viewsets.ModelViewSet):
         return queryset
 
 
+"""Get all vote system states"""
 class SystemStateViewSet(viewsets.ModelViewSet):
     http_method_names = ['get']
     queryset = SystemState.objects.all()

--- a/zapisy/apps/api/rest/v1/views.py
+++ b/zapisy/apps/api/rest/v1/views.py
@@ -59,21 +59,20 @@ class SpecialReservationViewSet(viewsets.ModelViewSet):
 
 
 class SingleVoteViewSet(viewsets.ModelViewSet):
-    """Return votes by selected state (or all votes otherwise)
+    """Returns votes by selected state (or all votes otherwise).
 
-    State is passed by GET parameter (e.g. url?state=n) 
-    Skip votes with no value for clarity
+    State is passed by GET parameter (e.g. url?state=n). Skips votes with no
+    value for clarity.
     """
-
     http_method_names = ['get']
     serializer_class = SingleVoteSerializer
     filter_fields = '__all__'
 
     def get_queryset(self):
-        queryset = SingleVote.objects.select_related('entity').all()
+        queryset = SingleVote.objects.select_related('entity').exclude(value=0, correction=0)
         system_state_id = self.request.GET.get('state')
         if system_state_id:
-            queryset = queryset.filter(state_id=system_state_id).exclude(value=0, correction=0)
+            queryset = queryset.filter(state_id=system_state_id)
 
         return queryset
 

--- a/zapisy/apps/api/rest/v1/views.py
+++ b/zapisy/apps/api/rest/v1/views.py
@@ -60,9 +60,10 @@ class SpecialReservationViewSet(viewsets.ModelViewSet):
 
 class SingleVoteViewSet(viewsets.ModelViewSet):
     """Return votes by selected state (or all votes otherwise)
-    
+
     State is passed by GET parameter (e.g. url?state=n) 
-    Skip votes with no value for clarity"""
+    Skip votes with no value for clarity
+    """
 
     http_method_names = ['get']
     serializer_class = SingleVoteSerializer

--- a/zapisy/apps/api/rest/v1/views.py
+++ b/zapisy/apps/api/rest/v1/views.py
@@ -58,9 +58,10 @@ class SpecialReservationViewSet(viewsets.ModelViewSet):
     filter_fields = '__all__'
 
 
-"""Return votes by selected state (or all votes otherwise)
-Skip votes with no value for clarity"""
 class SingleVoteViewSet(viewsets.ModelViewSet):
+    """Return votes by selected state (or all votes otherwise)
+    Skip votes with no value for clarity"""
+    
     http_method_names = ['get']
     serializer_class = SingleVoteSerializer
     filter_fields = '__all__'
@@ -74,8 +75,10 @@ class SingleVoteViewSet(viewsets.ModelViewSet):
         return queryset
 
 
-"""Get all vote system states"""
+
 class SystemStateViewSet(viewsets.ModelViewSet):
+    """Get all vote system states"""
+
     http_method_names = ['get']
     queryset = SystemState.objects.all()
     serializer_class = SystemStateSerializer

--- a/zapisy/apps/api/rest/v1/views.py
+++ b/zapisy/apps/api/rest/v1/views.py
@@ -60,6 +60,8 @@ class SpecialReservationViewSet(viewsets.ModelViewSet):
 
 class SingleVoteViewSet(viewsets.ModelViewSet):
     """Return votes by selected state (or all votes otherwise)
+    
+    State is passed by GET parameter (e.g. url?state=n) 
     Skip votes with no value for clarity"""
 
     http_method_names = ['get']

--- a/zapisy/apps/api/rest/v1/views.py
+++ b/zapisy/apps/api/rest/v1/views.py
@@ -64,7 +64,7 @@ class SingleVoteViewSet(viewsets.ModelViewSet):
     filter_fields = '__all__'
 
     def get_queryset(self):
-        queryset = SingleVote.objects.all()
+        queryset = SingleVote.objects.select_related('entity').all()
         system_state_id = self.request.GET.get('state')
         if system_state_id:
             queryset = queryset.filter(state_id=system_state_id).exclude(value=0, correction=0)

--- a/zapisy/apps/api/rest/v1/views.py
+++ b/zapisy/apps/api/rest/v1/views.py
@@ -5,13 +5,15 @@ from rest_framework.authentication import (BasicAuthentication,
 from apps.enrollment.courses.models.classroom import Classroom
 from apps.enrollment.courses.models.semester import Semester
 from apps.offer.desiderata.models import Desiderata, DesiderataOther
+from apps.offer.vote.models import SystemState
 from apps.schedule.models.specialreservation import SpecialReservation
 from apps.users.models import Employee
 from apps.users.utils import StaffPermission
 
 from .serializers import (ClassroomSerializer, DesiderataOtherSerializer,
                           DesiderataSerializer, EmployeeSerializer,
-                          SemesterSerializer, SpecialReservationSerializer)
+                          SemesterSerializer, SpecialReservationSerializer,
+                          SystemStateSerializer)
 
 
 class SemesterViewSet(viewsets.ModelViewSet):
@@ -53,4 +55,10 @@ class SpecialReservationViewSet(viewsets.ModelViewSet):
     http_method_names = ['get']
     queryset = SpecialReservation.objects.all()
     serializer_class = SpecialReservationSerializer
+    filter_fields = '__all__'
+
+class SystemStateViewSet(viewsets.ModelViewSet):
+    http_method_names = ['get']
+    queryset = SystemState.objects.all()
+    serializer_class = SystemStateSerializer
     filter_fields = '__all__'

--- a/zapisy/apps/api/rest/v1/views.py
+++ b/zapisy/apps/api/rest/v1/views.py
@@ -65,6 +65,7 @@ class SingleVoteViewSet(viewsets.ModelViewSet):
     value for clarity.
     """
     http_method_names = ['get']
+    permission_classes = (StaffPermission,)
     serializer_class = SingleVoteSerializer
     filter_fields = '__all__'
 
@@ -81,6 +82,7 @@ class SystemStateViewSet(viewsets.ModelViewSet):
     """Get all vote system states"""
 
     http_method_names = ['get']
+    permission_classes = (StaffPermission,)
     queryset = SystemState.objects.all()
     serializer_class = SystemStateSerializer
     filter_fields = '__all__'


### PR DESCRIPTION
Api requested in #480 and #481 

Some issues:
1.  I used `exclude(value=0, correction=0)`, but it won't be neccessary when #517 was merged
1.  ~~Getting course names seems to be very slow. Getting `/api/v1/votes?state=6` with them takes about 110 seconds,  getting only `id` takes 2 seconds. Any ideas?~~ 
1. What about perrmissions to this endpoint?
1. ~~I didn't know what the 'system state name' (#481 ) was, so I used a year field.~~