### PR TITLE
Fix error500 records

### DIFF
--- a/zapisy/apps/enrollment/records/views.py
+++ b/zapisy/apps/enrollment/records/views.py
@@ -257,7 +257,7 @@ def records(request, group_id):
             'mailto_queue_bcc': mailto(request.user, students_in_queue, True),
         })
         return render(request, 'enrollment/records/records_list.html', data)
-        
+
     except (NonGroupException, ObjectDoesNotExist):
         messages.info(request, "Podana grupa nie istnieje.")
         return render(request, 'common/error.html')


### PR DESCRIPTION
Fixes #395

Poprawione przechwycenie wyjątku w sytuacji kiedy dana grupa nie istnieje, przykładowo dla  http://zapisy.ii.uni.wroc.pl/records/14937/records zwracało
![przed](https://user-images.githubusercontent.com/15063185/48101173-6bcc8400-e226-11e8-87d6-4527a510441d.png)

Po
![po](https://user-images.githubusercontent.com/15063185/48101178-7129ce80-e226-11e8-913b-a0bce752192d.png)
