### PR TITLE
Webpack: poprawka dla systemów z jednym procesorem

### DIFF
--- a/zapisy/webpack_resources/webpack.config.ts
+++ b/zapisy/webpack_resources/webpack.config.ts
@@ -15,8 +15,11 @@ const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
 const UglifyJSPlugin = require("uglifyjs-webpack-plugin");
 const WebpackShellPlugin = require("webpack-shell-plugin");
 
-// Leave one cpu free for the ts type checker
-const happyThreadPool = HappyPack.ThreadPool({ size: os.cpus().length - 1 });
+// Leave one cpu free for the ts type checker...
+const happyThreadPool = HappyPack.ThreadPool({
+	// ...but make sure we spawn at least one thread
+	size: Math.max(os.cpus().length - 1, 1)
+});
 
 const smp = new SpeedMeasurePlugin();
 


### PR DESCRIPTION
Webpack uruchamia transformacje w wątkach, których tworzy <liczba (logicznych) procesorów> - 1; na systemach z jednym procesorem powstaje zatem problem. Ta łatka zapewnia, że zawsze uruchomimy co najmniej jeden wątek.