### PR TITLE
Attach some security-related HTTP headers

### DIFF
--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -279,6 +279,16 @@ SECURE_BROWSER_XSS_FILTER = True
 # JavaScript code in a text/plain file.
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
+# How long should our site be remembered to be HTTPS-only
+# by browsers.
+SECURE_HSTS_SECONDS = 60 * 60 * 24 * 365
+
+# Manifest the will to be included in so-called browser preload list,
+# physically distributed with browsers (Chrome for instance) to
+# basically do what HSTS would do, but even when a specific site
+# has never been seen before.
+SECURE_HSTS_PRELOAD = True
+
 DEBUG_TOOLBAR_ALLOWED_USERS = env.list('DEBUG_TOOLBAR_ALLOWED_USERS', default=[])
 DEBUG_TOOLBAR_PANELS = env.list('DEBUG_TOOLBAR_PANELS', default=[])
 

--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -160,6 +160,8 @@ TEMPLATES = [
 # and Authentication both must come before LocalePref which
 # must precede LocaleMiddleware, and Common must go afterwards.
 MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.http.ConditionalGetMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -263,6 +265,19 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 # doesn't have as many features, in particular it cannot serialize
 # custom objects, and we need this behavior.
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+
+# Attach X-XSS-Protection header to all outgoing HTTP responses.
+# It tells conformant browsers to activate their built-in
+# XSS (cross-site scripting attack) detection filter.
+SECURE_BROWSER_XSS_FILTER = True
+
+# Attach X-Content-Type-Options header with a value of nosniff
+# to all outgoing HTTP responses.
+# What it does is preventing the browser from trying to guess
+# a file type by 'sniffing' (applying some heuristic algorithms to) it.
+# Such feature can be abused in surprising ways, e.g. by disguising
+# JavaScript code in a text/plain file.
+SECURE_CONTENT_TYPE_NOSNIFF = True
 
 DEBUG_TOOLBAR_ALLOWED_USERS = env.list('DEBUG_TOOLBAR_ALLOWED_USERS', default=[])
 DEBUG_TOOLBAR_PANELS = env.list('DEBUG_TOOLBAR_PANELS', default=[])


### PR DESCRIPTION
Dodałem kilka nagłówków zapewnianych przez Django out of the box - ich brak być może nie jest w naszym przypadku krytycznym problemem, ale zawsze lepiej je mieć niż nie mieć ;]

Nie byłem natomiast pewien co do `Strict-Transport-Security` - _wszystkie_ requesty kierowane do serwera produkcyjnego (w sensie domeny `zapisy.ii.uni.wroc.pl`) są przekierowywane na HTTPS, prawda? Po pobieżnym przejrzeniu nie znalazłem żadnych wyjątkow, ale jeśli nie, to cóż, jednak lepiej go nie ruszać.

https://infosec.mozilla.org/guidelines/web_security#x-frame-options
https://infosec.mozilla.org/guidelines/web_security#x-content-type-options
https://infosec.mozilla.org/guidelines/web_security#x-xss-protection
https://infosec.mozilla.org/guidelines/web_security#http-strict-transport-security