### PR TITLE
Prace dyplomowe 1: lepsze zarządzanie użytkownikami w grupach

### DIFF
--- a/zapisy/apps/users/admin.py
+++ b/zapisy/apps/users/admin.py
@@ -121,7 +121,7 @@ class EmployeeInline(admin.StackedInline):
 
 class UserAdmin(DjangoUserAdmin):
     def user_groups(self, user):
-        group_names = map(lambda g: g.name, user.groups.all())
+        return ', '.join(group.name for group in user.groups.all())
         return ', '.join(group_names)
     user_groups.short_description = 'Grupy'
 

--- a/zapisy/apps/users/admin.py
+++ b/zapisy/apps/users/admin.py
@@ -122,7 +122,6 @@ class EmployeeInline(admin.StackedInline):
 class UserAdmin(DjangoUserAdmin):
     def user_groups(self, user):
         return ', '.join(group.name for group in user.groups.all())
-        return ', '.join(group_names)
     user_groups.short_description = 'Grupy'
 
     inlines = [StudentInline, EmployeeInline]

--- a/zapisy/apps/users/admin.py
+++ b/zapisy/apps/users/admin.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User, Group
 from django import forms
 import django.forms.models
 from django.contrib.auth import admin as django_auth_admin
+from django.db.models import QuerySet
 import csv
 
 from apps.users.models import (

--- a/zapisy/apps/users/admin.py
+++ b/zapisy/apps/users/admin.py
@@ -4,7 +4,6 @@ from django.contrib.auth.models import User, Group
 from django import forms
 import django.forms.models
 from django.contrib.auth import admin as django_auth_admin
-from django.db.models import QuerySet
 import csv
 
 from apps.users.models import (
@@ -119,12 +118,18 @@ class EmployeeInline(admin.StackedInline):
 
 
 class UserAdmin(django_auth_admin.UserAdmin):
-    def user_groups(self, user):
+    def show_user_groups(self, user: User):
+        """Django requires that all fields are model attributes or admin callables,
+        so we need this extra method
+        """
         return ', '.join(group.name for group in user.groups.all())
-    user_groups.short_description = 'Grupy'
+    show_user_groups.short_description = 'Grupy'
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).prefetch_related('groups')
 
     inlines = [StudentInline, EmployeeInline]
-    list_display = ('username', 'email', 'first_name', 'last_name', 'is_active', 'is_staff', 'user_groups')
+    list_display = ('username', 'email', 'first_name', 'last_name', 'is_active', 'is_staff', 'show_user_groups')
     list_filter = ('is_active', 'is_staff')
 
 

--- a/zapisy/apps/users/admin.py
+++ b/zapisy/apps/users/admin.py
@@ -1,7 +1,10 @@
 from django.http import HttpResponse, HttpRequest
 from django.contrib import admin
-from django.contrib.auth.models import User
-from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
+from django.contrib.auth.models import User, Group
+from django import forms
+from django.contrib.auth.admin import (
+    UserAdmin as DjangoUserAdmin, GroupAdmin as DjangoGroupAdmin
+)
 from django.db.models import QuerySet
 import csv
 
@@ -117,8 +120,13 @@ class EmployeeInline(admin.StackedInline):
 
 
 class UserAdmin(DjangoUserAdmin):
+    def user_groups(self, user):
+        group_names = map(lambda g: g.name, user.groups.all())
+        return ', '.join(group_names)
+    user_groups.short_description = 'Grupy'
+
     inlines = [StudentInline, EmployeeInline]
-    list_display = ('username', 'email', 'first_name', 'last_name', 'is_active', 'is_staff')
+    list_display = ('username', 'email', 'first_name', 'last_name', 'is_active', 'is_staff', 'user_groups')
     list_filter = ('is_active', 'is_staff')
 
 
@@ -129,3 +137,41 @@ admin.site.register(User, UserAdmin)
 admin.site.register(Employee, EmployeeAdmin)
 admin.site.register(Student, StudentAdmin)
 admin.site.register(Program, ProgramAdmin)
+
+
+class GroupAdminForm(forms.ModelForm):
+    """
+    ModelForm that adds an additional multiple select field for managing
+    the users in the group.
+    """
+    users = forms.ModelMultipleChoiceField(
+        User.objects.all(),
+        widget=admin.widgets.FilteredSelectMultiple('Users', False),
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(GroupAdminForm, self).__init__(*args, **kwargs)
+        if self.instance.pk:
+            initial_users = self.instance.user_set.values_list('pk', flat=True)
+            self.initial['users'] = initial_users
+
+    def save(self, *args, **kwargs):
+        kwargs['commit'] = True
+        return super(GroupAdminForm, self).save(*args, **kwargs)
+
+    def save_m2m(self):
+        self.instance.user_set.clear()
+        self.instance.user_set.add(*self.cleaned_data['users'])
+
+
+class GroupAdmin(DjangoGroupAdmin):
+    """
+    Customized GroupAdmin class that uses the customized form to allow
+    management of users within a group.
+    """
+    form = GroupAdminForm
+
+
+admin.site.unregister(Group)
+admin.site.register(Group, GroupAdmin)


### PR DESCRIPTION
PR wprowadza dwa udogodnienia:
* w widoku grupy w adminie dostępna jest lista wszystkich użytkowników w tej grupie z możliwością dodania kolejnych (widget znany z innych części Django: https://gyazo.com/77e32509b0207470071953b13186dfeb) - wydaje się dziwne, że Django nie ma tego domyślnie
* w widoku listy użytkowników dochodzi nowa kolumna, która wyświetla wszystkie grupy danego użytkownika: https://gyazo.com/620ae95e4dd69f34cd80cd4438f667d8

Zmiany te przydadzą się także w systemie zarządzania pracami dyplomowymi, ponieważ pojawia się tam pojęcie _komisji prac dyplomowych_, która zrealizowana będzie jako osobna grupa.