### PR TITLE
Poprawki konfiguracji Webpacka

### DIFF
--- a/zapisy/package.json
+++ b/zapisy/package.json
@@ -6,7 +6,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "NODE_ENV=development TS_NODE_PROJECT=\"tsconfig.webpack-config.json\" webpack --progress --colors --config webpack_resources/webpack.config.ts",
     "devw": "NODE_ENV=development TS_NODE_PROJECT=\"tsconfig.webpack-config.json\" webpack --progress --colors --watch --config webpack_resources/webpack.config.ts",
-    "build": "NODE_ENV=production TS_NODE_PROJECT=\"tsconfig.webpack-config.json\" webpack --progress --colors --config webpack_resources/webpack.config.ts"
+    "build": "NODE_ENV=production TS_NODE_PROJECT=\"tsconfig.webpack-config.json\" webpack --config webpack_resources/webpack.config.ts"
   },
   "repository": {
     "type": "git",
@@ -51,15 +51,14 @@
     "less-loader": "^4.1.0",
     "node-sass": "^4.7.2",
     "sass-loader": "^6.0.6",
-    "speed-measure-webpack-plugin": "^1.2.2",
     "style-loader": "^0.21.0",
+    "terser-webpack-plugin": "^1.1.0",
     "ts-loader": "^4.4.1",
     "ts-node": "^3.3.0",
     "tsconfig-paths": "^3.4.0",
     "tslint": "^5.8.0",
     "tslint-config-standard": "^7.0.0",
-    "typescript": "^2.9.2",
-    "uglifyjs-webpack-plugin": "^2.0.1",
+    "typescript": "^3.2.2",
     "url-loader": "^1.0.1",
     "vue-loader": "^13.5.0",
     "vue-style-loader": "^3.0.3",

--- a/zapisy/webpack_resources/webpack.config.ts
+++ b/zapisy/webpack_resources/webpack.config.ts
@@ -11,8 +11,7 @@ import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
 const BundleTracker = require("webpack-bundle-tracker");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
-const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
-const UglifyJSPlugin = require("uglifyjs-webpack-plugin");
+const TerserWebpackPlugin = require("terser-webpack-plugin");
 const WebpackShellPlugin = require("webpack-shell-plugin");
 
 // Leave one cpu free for the ts type checker...
@@ -20,8 +19,6 @@ const happyThreadPool = HappyPack.ThreadPool({
 	// ...but make sure we spawn at least one thread
 	size: Math.max(os.cpus().length - 1, 1)
 });
-
-const smp = new SpeedMeasurePlugin();
 
 let DEV: boolean;
 switch (process.env.NODE_ENV) {
@@ -166,21 +163,20 @@ const webpackConfig: webpack.Configuration = {
 	devtool: DEV ? "inline-cheap-module-source-map" as any : false,
 	mode: DEV ? "development" : "production",
 	optimization: {
-		// This is only applied if optimization.minimize is true (mode === "development")
+		// This is only applied if optimization.minimize is true (mode === "production")
 		minimizer: [
-			new UglifyJSPlugin({
+			new TerserWebpackPlugin({
 				sourceMap: false,
 				parallel: true,
-				uglifyOptions: {
-					compress: true,
-					output: { comments: false },
-					comments: false,
-					ecma: 5,
+				terserOptions: {
+					parse: { ecma: 8 },
 					mangle: {
 						toplevel: true,
 						eval: true,
 					},
-					hoist_funs: true,
+					output: {
+						comments: false,
+					}
 				},
 			}),
 		],
@@ -245,9 +241,7 @@ const webpackConfig: webpack.Configuration = {
 					),
 					esModule: true,
 					postcss: [
-					  require("autoprefixer")({
-						browsers: ["last 2 versions"]
-					  })
+						require("autoprefixer")({ browsers: ["last 2 versions"] })
 					],
 				},
 			},

--- a/zapisy/yarn.lock
+++ b/zapisy/yarn.lock
@@ -1274,7 +1274,7 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
-cacache@^11.0.2, cacache@^11.2.0:
+cacache@^11.0.2:
   version "11.3.1"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.1.tgz#d09d25f6c4aca7a6d305d141ae332613aa1d515f"
   integrity sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==
@@ -1378,7 +1378,7 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
@@ -5220,13 +5220,6 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz#a59efc09784c2a5bada13cfeaf5c75dd214044d2"
   integrity sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==
 
-speed-measure-webpack-plugin@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.2.3.tgz#de170b5cefbfa1c039d95e639edd3ad50cfc7c48"
-  integrity sha512-p+taQ69VkRUXYMoZOx2nxV/Tz8tt79ahctoZJyJDHWP7fEYvwFNf5Pd73k5kZ6auu0pTsPNLEUwWpM8mCk85Zw==
-  dependencies:
-    chalk "^2.0.1"
-
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -5708,32 +5701,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
-
-uglify-js@^3.0.0:
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
-  integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==
-  dependencies:
-    commander "~2.17.1"
-    source-map "~0.6.1"
-
-uglifyjs-webpack-plugin@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.0.1.tgz#f346af53ed496ce72fef462517d417f62bec3010"
-  integrity sha512-1HhCHkOB6wRCcv7htcz1QRPVbWPEY074RP9vzt/X0LF4xXm9l4YGd0qja7z88abDixQlnVwBjXsTBs+Xsn/eeQ==
-  dependencies:
-    cacache "^11.2.0"
-    find-cache-dir "^2.0.0"
-    schema-utils "^1.0.0"
-    serialize-javascript "^1.4.0"
-    source-map "^0.6.1"
-    uglify-js "^3.0.0"
-    webpack-sources "^1.1.0"
-    worker-farm "^1.5.2"
+typescript@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
* upgrade Typescript do najnowszej wersji 3.2.2
* przechodzimy z UglifyJS na Terser. W skrócie: do tej pory `uglifyjs-webpack-plugin` korzystał z `uglify-es`, które radzi sobie z optymalizacją es6, ale zostało porzucone. Nowe wersje `uglifyjs-webpack-plugin` (> 2.0.0) przerzuciły się na `UglifyJS`, ale on nie potrafi pracować z ES6+. Rozwiązaniem jest utrzymywany fork `uglify-es` o nazwie Terser, z którego panowie z Webpacka planują korzystać w kolejnej wersji (https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/362), więc powinien być bezpiecznym wyborem.
* wyrzucenie opcji progress z opcji `build` w package.json; dodanie jej tam było błędem, bo konsola w CircleCI i podobnych serwisach nie obsługuje powrotu/czyszczenia linii, wobec czego log z kompilacji wygląda tak: https://gyazo.com/a4df70d2e1e94a5663e9c23b7faacd0b
* wyrzucenie nieużywanego speed-measure-plugina