### PR TITLE
Prace dyplomowe 2: tytuły naukowe pracowników

### DIFF
--- a/zapisy/apps/users/admin.py
+++ b/zapisy/apps/users/admin.py
@@ -93,11 +93,20 @@ class EmployeeAdmin(admin.ModelAdmin):
     list_filter = ('status',)
     search_fields = ('user__first_name', 'user__last_name', 'user__username')
     fieldsets = [
-        (None, {
-            'fields': [
-                'user', 'status', 'homepage', 'room', 'consultations']}), ('Ogłoszenia mailowe', {
-                    'fields': [
-                        'receive_mass_mail_enrollment', 'receive_mass_mail_offer'], 'classes': ['collapse']}), ]
+        (
+            None,
+            {
+                'fields': ['user', 'status', 'homepage', 'room', 'consultations', 'title']
+            }
+        ),
+        (
+            'Ogłoszenia mailowe',
+            {
+                'fields': ['receive_mass_mail_enrollment', 'receive_mass_mail_offer'],
+                'classes': ['collapse']
+            }
+        ),
+    ]
     ordering = ['user__last_name', 'user__first_name']
     list_display_links = ('get_full_name',)
 

--- a/zapisy/apps/users/models.py
+++ b/zapisy/apps/users/models.py
@@ -168,7 +168,10 @@ class Employee(BaseUser):
             ("mailto_all_students", "Może wysyłać maile do wszystkich studentów"),
         )
 
-    def get_full_name(self) -> str:
+    def get_full_name_with_academic_title(self) -> str:
+        """Same as get_full_name(), but prepends the employee's academic title
+        if one is defined.
+        """
         base_name = super().get_full_name()
         return f'{self.title} {base_name}' if self.title else base_name
 
@@ -285,9 +288,6 @@ class Student(BaseUser):
         verbose_name_plural: str = 'studenci'
         app_label: str = 'users'
         ordering: List[str] = ['user__last_name', 'user__first_name']
-
-    def __str__(self) -> str:
-        return self.user.get_full_name()
 
 
 class Program(models.Model):

--- a/zapisy/apps/users/models.py
+++ b/zapisy/apps/users/models.py
@@ -169,7 +169,7 @@ class Employee(BaseUser):
         )
 
     def get_full_name(self) -> str:
-        base_name = super(Employee, self).get_full_name()
+        base_name = super().get_full_name()
         return f'{self.title} {base_name}' if self.title else base_name
 
 

--- a/zapisy/apps/users/models.py
+++ b/zapisy/apps/users/models.py
@@ -169,7 +169,7 @@ class Employee(BaseUser):
         )
 
     def get_full_name_with_academic_title(self) -> str:
-        """Same as get_full_name(), but prepends the employee's academic title
+        """Same as `get_full_name`, but prepends the employee's academic title
         if one is defined.
         """
         base_name = super().get_full_name()

--- a/zapisy/apps/users/models.py
+++ b/zapisy/apps/users/models.py
@@ -168,8 +168,9 @@ class Employee(BaseUser):
             ("mailto_all_students", "Może wysyłać maile do wszystkich studentów"),
         )
 
-    def __str__(self) -> str:
-        return self.user.get_full_name()
+    def get_full_name(self) -> str:
+        base_name = super(Employee, self).get_full_name()
+        return f'{self.title} {base_name}' if self.title else base_name
 
 
 class Student(BaseUser):


### PR DESCRIPTION
Na modelu `Employee` znajduje się pole `title`, które w zamyśle ma przechowywać tytuł naukowy pracownika, ale z jakiegoś powodu zostało ono wyłączone w adminie. PR przywraca je w adminie i dodaje na modelu `Employee` funkcję `get_full_name_with_academic_title`, która zwraca imię i nazwisko wraz z tytułem naukowym (funkcjonalność potrzebna do systemu prac dyplomowych, gdzie promotorzy mają być wyświetlani z tytułami)