### PR TITLE
Prace dyplomowe 3: możliwość schowania niebieskiego paska z logo UWr na górze strony

### DIFF
--- a/zapisy/templates/base.html
+++ b/zapisy/templates/base.html
@@ -176,6 +176,7 @@
             </div>
         </nav>
         <div class="top">
+            {% block uwr_logo %}
             <div class="logo header">
                 <div class="container">
                     <a href="/">
@@ -183,6 +184,7 @@
                     </a>
                 </div>
             </div>
+            {% endblock %}
             <div class="container">
                 <div class="row">
                     <div id="system_menu"> 


### PR DESCRIPTION
W tym PR niebieski pasek z logo UWr został wrzucony do osobnego bloku. LPi zależy, by cała aplikacja prac dyplomowych mieściła się na ekranie, o ile to możliwe. W związku z tym prosił o niewyświetlanie nad nią paska z logo UWr, który niepotrzebnie zabiera miejsce. Dzięki wrzuceniu go do bloku template'y dziedziczące po `base.html` mają możliwość go usunąć.

Przeglądający mogą dojść do słusznego wniosku, że tak mała zmiana nie zasługuje na osobny PR. W przeszłości w tym PR zmian było więcej, ale dzięki wprowadzeniu Bootstrapa 4 przestały one być potrzebne.