### PR TITLE
Prace dyplomowe 8: testy

### DIFF
--- a/zapisy/apps/api/rest/v1/tests/test_api.py
+++ b/zapisy/apps/api/rest/v1/tests/test_api.py
@@ -89,21 +89,21 @@ class VoteSystemTests(TestCase):
         response = client.get('/api/v1/votes/', {'state': self.state2.pk}, format='json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 3)
-        self.assertDictEqual(response.data[0], {
-            'student': self.students[1].pk,
-            'course_name': "Pranie",
-            'vote_points': 1
-        })
-        self.assertDictEqual(response.data[1], {
-            'student': self.students[0].pk,
-            'course_name': "Zmywanie",
-            'vote_points': 3
-        })
-        self.assertDictEqual(response.data[2], {
-            'student': self.students[1].pk,
-            'course_name': "Zmywanie",
-            'vote_points': 2
-        })
+        self.assertCountEqual(response.data, [
+            {
+                'student': self.students[1].pk,
+                'course_name': "Pranie",
+                'vote_points': 1
+            }, {
+                'student': self.students[0].pk,
+                'course_name': "Zmywanie",
+                'vote_points': 3
+            }, {
+                'student': self.students[1].pk,
+                'course_name': "Zmywanie",
+                'vote_points': 2
+            }
+        ])
 
     def test_can_set_semester_usos_kod(self):
         """Tests semester endpoint.

--- a/zapisy/apps/theses/tests/base.py
+++ b/zapisy/apps/theses/tests/base.py
@@ -1,0 +1,241 @@
+import random
+from typing import Callable, List
+
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.urls import reverse
+from django.contrib.auth.models import Group
+
+from apps.users.models import Employee, Student, BaseUser
+from apps.users.tests.factories import EmployeeFactory, StudentFactory
+from ..models import (
+    Thesis, ThesisVote, ThesisStatus, VoteToProcess,
+    ThesesSystemSettings
+)
+
+from ..users import THESIS_BOARD_GROUP_NAME
+
+from .utils import (
+    random_title, random_bool,
+    random_kind, random_current_status, random_reserved_until,
+    random_description, random_definite_vote,
+)
+
+PAGE_SIZE = 100
+
+
+class ThesesBaseTestCase(APITestCase):
+    """A test case base class for theses tests that takes care of user creation
+    and provides common utilities
+    """
+    @classmethod
+    def setUpTestData(cls):
+        cls.create_users()
+
+    NUM_BOARD_MEMBERS = 7
+
+    @classmethod
+    def create_users(cls):
+        NUM_STUDENTS = 15
+        NUM_EMPLOYEES = cls.NUM_BOARD_MEMBERS * 2
+        StudentFactory.create_batch(NUM_STUDENTS)
+        EmployeeFactory.create_batch(NUM_EMPLOYEES)
+        cls.students = list(Student.objects.all())
+        cls.employees = list(Employee.objects.all())
+        cls.board_group = Group.objects.get(name=THESIS_BOARD_GROUP_NAME)
+
+        cls.staff_user = Employee.objects.all()[0]
+        cls.staff_user.user.is_staff = True
+        cls.staff_user.user.save()
+
+        cls.board_members = []
+        for i in range(cls.NUM_BOARD_MEMBERS):
+            member = Employee.objects.all()[i]
+            cls.board_members.append(member)
+            cls.board_group.user_set.add(member.user)
+
+        cls.rejecter = random.choice(cls.board_members)
+        settings = ThesesSystemSettings.objects.get()
+        settings.master_rejecter = cls.rejecter
+        settings.save()
+
+    @classmethod
+    def get_random_emp(cls):
+        """Return a random employee (not an admin or a board member)"""
+        return random.choice(cls.employees[1 + cls.NUM_BOARD_MEMBERS:])
+
+    @classmethod
+    def get_random_emp_different_from(cls, emp):
+        """Return a random employee different from the specified employee"""
+        result = cls.get_random_emp()
+        while result == emp:
+            result = cls.get_random_emp()
+        return result
+
+    @classmethod
+    def get_admin(cls):
+        return cls.staff_user
+
+    @classmethod
+    def get_random_board_member(cls):
+        """Get a random member of the theses board, _possibly the admin_"""
+        return random.choice(cls.board_members)
+
+    @classmethod
+    def get_random_board_member_other_than(cls, members: List[Employee]):
+        """Return a random board member different from the specified one"""
+        result = cls.get_random_board_member()
+        while members and result in members:
+            result = cls.get_random_board_member()
+        return result
+
+    @classmethod
+    def get_random_board_member_not_admin(cls):
+        """Get a random board member, but not the admin"""
+        return cls.get_random_board_member_other_than([cls.get_admin()])
+
+    @classmethod
+    def get_random_board_member_not_rejecter(cls):
+        return cls.get_random_board_member_other_than([cls.get_rejecter()])
+
+    @classmethod
+    def get_random_board_member_not_admin_or_rejecter(cls):
+        return cls.get_random_board_member_other_than([
+            cls.get_rejecter(), cls.get_admin(),
+        ])
+
+    @classmethod
+    def get_rejecter(cls):
+        return cls.rejecter
+
+    @classmethod
+    def get_random_student(cls):
+        return random.choice(cls.students)
+
+    @classmethod
+    def get_random_students(cls, num_students: int) -> List[Student]:
+        """Get the specified number of unique random students"""
+        assert num_students < len(cls.students)
+        result = []
+        while len(result) < num_students:
+            s = cls.get_random_student()
+            while s in result:
+                s = cls.get_random_student()
+            result.append(s)
+        return result
+
+    @classmethod
+    def make_thesis_nosave(cls, **kwargs):
+        """Create a thesis instance using the provided params or defaults,
+        without saving it (only creates an instance)
+        Because students is a m2m relationship, no students will be assigned"""
+        return Thesis(
+            title=kwargs.get("title", random_title()),
+            advisor=kwargs.get("advisor", cls.get_random_emp()),
+            supporting_advisor=kwargs.get(
+                "supporting_advisor", cls.get_random_emp() if random_bool() else None
+            ),
+            kind=kwargs.get("kind", random_kind()).value,
+            status=kwargs.get("status", random_current_status()).value,
+            reserved_until=kwargs.get("reserved_until", random_reserved_until()),
+            description=kwargs.get("description", random_description()),
+        )
+
+    @classmethod
+    def make_thesis(cls, **kwargs):
+        """Like make_thesis, but also saves to the DB.
+        This allows the method to assign students
+        """
+        if "students" in kwargs:
+            students = kwargs.pop("students")
+        else:
+            students = cls.get_random_students(random.randint(1, 10))
+        result = cls.make_thesis_nosave(**kwargs)
+        result.save()
+        result.set_students(students)
+        return result
+
+    def get_board_members(self, num: int, to_skip: Employee=None):
+        def get_voter():
+            if to_skip:
+                return self.get_random_board_member_other_than([to_skip])
+            return self.get_random_board_member()
+        voters = []
+        while len(voters) < num:
+            voter = get_voter()
+            while voter in voters:
+                voter = get_voter()
+            voters.append(voter)
+        return voters
+
+    def login_as(self, user: BaseUser):
+        """Login as the specified user"""
+        self.client.login(username=user.user.username, password="test")
+
+    def get_response_with_data(self, data={}):
+        """Make a request to the theses list endpoint with the specified params,
+        return the raw response
+        """
+        url = reverse("theses:theses-list")
+        if "limit" not in data:
+            data["limit"] = PAGE_SIZE
+        return self.client.get(url, data)
+
+    def get_theses_with_data(self, data={}):
+        """Download and return theses with the provided params"""
+        response = self.get_response_with_data(data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.data["results"]
+
+    def create_theses_for_ungraded_testing(self, board_member: Employee):
+        """
+        Create two batches of theses, one graded, the other one not
+        graded or graded with indeterminate vote values for the given
+        board member"""
+        num_theses = random.randint(10, 20)
+        graded_theses = [self.make_thesis(status=ThesisStatus.BEING_EVALUATED) for _ in range(num_theses)]
+        ungraded_theses = [self.make_thesis(status=ThesisStatus.BEING_EVALUATED) for _ in range(num_theses)]
+        for graded in graded_theses:
+            self.set_thesis_vote_locally(graded, board_member, random_definite_vote())
+        # Also cast "indeterminate" votes for some "ungraded" theses,
+        # they should still count as ungraded with those vote values
+        ungraded_with_indeterminate = random.sample(ungraded_theses, random.randrange(num_theses))
+        for thesis in ungraded_with_indeterminate:
+            self.set_thesis_vote_locally(thesis, board_member, {"value": ThesisVote.NONE})
+        # Pick a few theses, set them to one of the unchangeable statues;
+        # they shouldn't count anymore
+        unchangeable_theses = random.sample(ungraded_theses, random.randrange(num_theses // 3))
+        # only "being evaluated" is counted as ungraded
+        uncounted_statuses = list(set(list(ThesisStatus)) - set((ThesisStatus.BEING_EVALUATED, )))
+        for unchangeable in unchangeable_theses:
+            unchangeable.status = random.choice(uncounted_statuses).value
+            unchangeable.save()
+        # They shouldn't be counted as ungraded anymore
+        ungraded_theses = list(set(ungraded_theses) - set(unchangeable_theses))
+        return graded_theses, ungraded_theses
+
+    def set_thesis_vote_locally(self, thesis: Thesis, voter: Employee, vote: ThesisVote):
+        """Set the specified vote value for the specified employee locally,
+        not through the API
+        """
+        vote_to_process = VoteToProcess(voter, vote["value"], vote.get("reason"))
+        thesis.process_new_votes((vote_to_process, ), voter, True)
+
+    def run_test_with_privileged_users(
+        self, test_func: Callable[[Employee], None],
+    ):
+        """Run the provided testing function with all privileged user types,
+        that is an employee, a non admin board member, and the admin
+        """
+        test_func(self.get_random_emp())
+        self.run_test_with_board_members(test_func)
+
+    def run_test_with_board_members(
+        self, test_func: Callable[[Employee], None],
+    ):
+        """Run the provided testing function with a non admin board member
+        and the admin
+        """
+        admin = self.get_admin()
+        test_func(self.get_random_board_member_not_admin())
+        test_func(admin)

--- a/zapisy/apps/theses/tests/test_addition.py
+++ b/zapisy/apps/theses/tests/test_addition.py
@@ -1,0 +1,102 @@
+from rest_framework import status
+from django.urls import reverse
+
+from apps.users.models import Employee, BaseUser
+from ..models import ThesisStatus
+from .utils import random_title, random_kind, random_reserved_until
+from .base import ThesesBaseTestCase
+
+
+class ThesesAdditionTestCase(ThesesBaseTestCase):
+    def add_thesis(self, adder: Employee, **kwargs):
+        """Try to add a thesis with the specified params
+        (or defaults if missing) as the specified user
+        """
+        self.login_as(adder)
+        advisor = kwargs.pop("advisor", adder)
+        base_data = {
+            "title": random_title(),
+            "advisor": advisor.pk,
+            "kind": random_kind().value,
+            "reserved_until": random_reserved_until(),
+            "status": ThesisStatus.BEING_EVALUATED.value
+        }
+        base_data.update(kwargs)
+        return self.client.post(reverse("theses:theses-list"), base_data, format="json")
+
+    # Students can't add a thesis
+    def test_student_cannot_add_thesis(self):
+        stud = self.get_random_student()
+        emp = self.get_random_emp()
+        # Use a separate employee as the advisor to make sure the request
+        # isn't rejected just because the advisor is invalid and actually
+        # looks at the user sending it
+        response = self.add_thesis(stud, advisor=emp)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # Regular employees cannot add a thesis with someone else as the advisor
+    def test_employee_can_add_own_thesis(self):
+        emp = self.get_random_emp()
+        response = self.add_thesis(emp)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_employee_cannot_add_someone_elses_thesis(self):
+        emp = self.get_random_emp()
+        other_emp = self.get_random_emp_different_from(emp)
+        response = self.add_thesis(emp, advisor=other_emp)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # ...or with status set to anything other than being evaluated
+    def test_employee_cannot_add_thesis_with_other_status(self):
+        emp = self.get_random_emp()
+        response = self.add_thesis(emp, status=ThesisStatus.ACCEPTED.value)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # But board members can
+    def test_board_member_can_add_someone_elses_thesis(self):
+        emp = self.get_random_board_member()
+        other_emp = self.get_random_emp_different_from(emp)
+        response = self.add_thesis(emp, advisor=other_emp)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_board_member_can_add_thesis_with_other_status(self):
+        emp = self.get_random_board_member()
+        response = self.add_thesis(emp, status=ThesisStatus.ACCEPTED.value)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    # Theses with empty titles are not permitted
+    def ensure_user_cannot_add_thesis_with_empty_title(self, user):
+        response = self.add_thesis(user, title="")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_cannot_add_thesis_with_empty_title(self):
+        self.ensure_user_cannot_add_thesis_with_empty_title(self.get_random_emp())
+        board_member = self.get_random_board_member_not_admin()
+        self.ensure_user_cannot_add_thesis_with_empty_title(board_member)
+        self.ensure_user_cannot_add_thesis_with_empty_title(self.get_admin())
+
+    def ensure_409_with_user(self, user: BaseUser):
+        title = random_title()
+        thesis = self.make_thesis(title=title)
+        # Padding at each end should be trimmed, so this is still a dupe
+        padded_title = f'  \t{title}    \n   '
+        response = self.add_thesis(user, title=padded_title)
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    # Titles must be unique, for all users
+    def test_no_one_can_add_thesis_with_duplicate_title(self):
+        self.run_test_with_privileged_users(self.ensure_409_with_user)
+
+    def ensure_cannot_add_invalid_kind_as_user(self, user: BaseUser):
+        response = self.add_thesis(user, kind=123)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_cannot_add_invalid_kind(self):
+        self.run_test_with_privileged_users(self.ensure_cannot_add_invalid_kind_as_user)
+
+    def ensure_cannot_add_invalid_status_as_user(self, user: BaseUser):
+        response = self.add_thesis(user, status=123)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_cannot_add_invalid_status(self):
+        self.run_test_with_privileged_users(self.ensure_cannot_add_invalid_status_as_user)

--- a/zapisy/apps/theses/tests/test_deletion.py
+++ b/zapisy/apps/theses/tests/test_deletion.py
@@ -1,0 +1,101 @@
+from rest_framework import status
+from django.urls import reverse
+
+from apps.users.models import Employee, BaseUser
+from ..models import ThesisStatus
+from ..permissions import EMPLOYEE_DELETABLE_STATUSES
+from ..enums import NOT_READY_STATUSES
+from .base import ThesesBaseTestCase
+
+
+class ThesesDeletionTestCase(ThesesBaseTestCase):
+    def setUp(self):
+        self.advisor = self.get_random_emp()
+        self.thesis = self.make_thesis(advisor=self.advisor, status=ThesisStatus.BEING_EVALUATED)
+
+    def delete_thesis(self, deleter: Employee, **kwargs):
+        """Try to delete the current thesis as the specified user
+        """
+        self.login_as(deleter)
+        return self.client.delete(f'{reverse("theses:theses-list")}{self.thesis.pk}/')
+
+    def _test_cannot_delete(self, person: BaseUser):
+        response = self.delete_thesis(person)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def _test_can_delete(self, person: BaseUser):
+        response = self.delete_thesis(person)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def _set_status(self, thesis_status: ThesisStatus):
+        self.thesis.status = thesis_status.value
+        self.thesis.save()
+
+    def _test_can_delete_with_status(self, person: Employee, thesis_status: ThesisStatus):
+        self._set_status(thesis_status)
+        self._test_can_delete(person)
+
+    def _test_cannot_delete_with_status(self, person: Employee, thesis_status: ThesisStatus):
+        self._set_status(thesis_status)
+        self._test_cannot_delete(person)
+
+    def test_student_cannot_delete_not_ready_thesis(self):
+        """Test that students cannot delete theses that are not ready yet
+        they should get a 404 since those aren't even visible to them
+        """
+        stud = self.get_random_student()
+        for thesis_status in NOT_READY_STATUSES:
+            self._set_status(thesis_status)
+            response = self.delete_thesis(stud)
+            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_student_cannot_delete_ready_thesis(self):
+        """Test that students get a 403 when they try to delete a thesis
+        that should be visible to them
+        """
+        stud = self.get_random_student()
+        for thesis_status in list(set(ThesisStatus) - set(NOT_READY_STATUSES)):
+            self._test_cannot_delete_with_status(stud, thesis_status)
+
+    def test_employee_can_delete_own_thesis_when_being_evaluated(self):
+        """Test that employees are allowed to delete their own thesis if it's still being evaluated"""
+        self._test_can_delete_with_status(self.advisor, ThesisStatus.BEING_EVALUATED)
+
+    def test_employee_can_delete_own_thesis_when_rejected(self):
+        """Test that employees are allowed to delete their own thesis if it's been returned for corrections"""
+        self._test_can_delete_with_status(self.advisor, ThesisStatus.RETURNED_FOR_CORRECTIONS)
+
+    def test_employee_cannot_delete_own_thesis_after_accepted(self):
+        """Test that employees cannot delete their own thesis after it's been accepted"""
+        post_accept = list(set(ThesisStatus) - set(EMPLOYEE_DELETABLE_STATUSES))
+        for thesis_status in post_accept:
+            self._test_cannot_delete_with_status(self.advisor, thesis_status)
+
+    def test_employee_cannot_delete_someone_elses_thesis(self):
+        """Test that employees are not allowed to delete someone else's theses"""
+        other_emp = self.get_random_emp_different_from(self.advisor)
+        self._test_cannot_delete(other_emp)
+
+    def test_board_member_can_delete_someone_elses_thesis(self):
+        """Test that board members are allowed to delete someone else's theses"""
+        member = self.get_random_board_member_not_admin()
+        self._test_can_delete(member)
+
+    def test_board_member_can_delete_accepted_thesis(self):
+        member = self.get_random_board_member_not_admin()
+        self._test_can_delete_with_status(member, ThesisStatus.ACCEPTED)
+
+    def test_board_member_cannot_delete_archived_thesis(self):
+        """Board members are not allowed to modify or delete archived theses"""
+        member = self.get_random_board_member_not_admin()
+        self._test_cannot_delete_with_status(member, ThesisStatus.DEFENDED)
+
+    def test_admin_can_delete_someone_elses_thesis(self):
+        self._test_can_delete(self.get_admin())
+
+    def test_admin_can_delete_accepted_thesis(self):
+        self._test_can_delete_with_status(self.get_admin(), ThesisStatus.ACCEPTED)
+
+    def test_admin_cannot_delete_archived_thesis(self):
+        """Admins are allowed to delete even archived theses"""
+        self._test_can_delete_with_status(self.get_admin(), ThesisStatus.DEFENDED)

--- a/zapisy/apps/theses/tests/test_filters_and_sort.py
+++ b/zapisy/apps/theses/tests/test_filters_and_sort.py
@@ -1,0 +1,161 @@
+import random
+
+from apps.users.models import Employee
+
+from ..models import Thesis, ThesisStatus, ThesisKind
+from ..views import ThesisTypeFilter
+from .base import ThesesBaseTestCase, PAGE_SIZE
+from .utils import (
+    random_current_status, random_available_status,
+    random_status, make_employee_with_name, exactly_one,
+    random_reserved_until
+)
+
+
+class ThesesFiltersAndSortingTestCase(ThesesBaseTestCase):
+    """Tests the the filtering & sorting functionality works correctly"""
+    def login_for_perms(self):
+        """A simple helper that logs in as any user authorized to view theses
+        so that we can test filters"""
+        self.login_as(self.get_random_emp())
+
+    def test_title_filter(self):
+        num_matching = random.randint(1, PAGE_SIZE // 2)
+        num_nonmatching = random.randint(1, PAGE_SIZE // 2)
+        title_base_match = "foobar"
+        title_base_nonmatch = "{}blahblah"
+        theses_matching = [
+            self.make_thesis_nosave(title=f'{title_base_match}_{i}') for i in range(num_matching)
+        ]
+        theses_nonmatching = [
+            self.make_thesis_nosave(title=title_base_nonmatch.format(i)) for i in range(num_nonmatching)
+        ]
+        Thesis.objects.bulk_create(theses_matching + theses_nonmatching)
+        self.login_for_perms()
+        theses = self.get_theses_with_data({"title": title_base_match})
+        self.assertEqual(len(theses), num_matching)
+        for thesis in theses:
+            self.assertTrue(title_base_match in thesis["title"])
+
+    def test_advisor_filter(self):
+        num_matching = random.randint(1, PAGE_SIZE // 2)
+        num_nonmatching = random.randint(1, PAGE_SIZE // 2)
+        matching_emp = self.get_random_emp()
+        nonmatching_emp = self.get_random_emp_different_from(matching_emp)
+        theses_matching = [
+            self.make_thesis_nosave(advisor=matching_emp) for i in range(num_matching)
+        ]
+        theses_nonmatching = [
+            self.make_thesis_nosave(advisor=nonmatching_emp) for i in range(num_nonmatching)
+        ]
+        Thesis.objects.bulk_create(theses_matching + theses_nonmatching)
+        self.login_for_perms()
+        theses = self.get_theses_with_data({"advisor": matching_emp.get_full_name()})
+        self.assertEqual(len(theses), num_matching)
+        for thesis in theses:
+            thesis_advisor = Employee.objects.get(pk=thesis["advisor"])
+            self.assertTrue(thesis_advisor == matching_emp)
+
+    def test_current_type_filter(self):
+        """Test that current, i.e. not yet defended theses are being filtered correctly"""
+        num_normal = random.randint(1, PAGE_SIZE // 2)
+        num_defended = random.randint(1, PAGE_SIZE // 2)
+        normal = [
+            self.make_thesis_nosave(status=random_current_status()) for i in range(num_normal)
+        ]
+        defended = [
+            self.make_thesis_nosave(status=ThesisStatus.DEFENDED) for i in range(num_defended)
+        ]
+        Thesis.objects.bulk_create(normal + defended)
+        self.login_for_perms()
+        theses = self.get_theses_with_data({"type": ThesisTypeFilter.CURRENT.value})
+        self.assertEqual(len(theses), num_normal)
+        for thesis in theses:
+            self.assertNotEqual(thesis["status"], ThesisStatus.DEFENDED.value)
+
+    def test_available_filter(self):
+        """Test that the "available of type" filter works correctly"""
+        num_matching_avail = random.randint(1, PAGE_SIZE // 3)
+        num_matching_unavail = random.randint(1, PAGE_SIZE // 3)
+        num_other = random.randint(1, PAGE_SIZE // 3)
+        matching_avail = [
+            self.make_thesis_nosave(
+                kind=ThesisKind.BACHELORS,
+                status=random_available_status(),
+                reserved_until=None,
+            ) for i in range(num_matching_avail)
+        ]
+        matching_unavail = [
+            self.make_thesis_nosave(
+                kind=ThesisKind.BACHELORS,
+                status=random_status() if i % 2 else ThesisStatus.IN_PROGRESS,
+                reserved_until=random_reserved_until() if bool(i % 2) else None
+            ) for i in range(num_matching_unavail)
+        ]
+        other = [
+            self.make_thesis_nosave(kind=ThesisKind.ISIM) for i in range(num_other)
+        ]
+        Thesis.objects.bulk_create(matching_avail + matching_unavail + other)
+        self.login_for_perms()
+        theses = self.get_theses_with_data({"type": ThesisTypeFilter.AVAILABLE_BACHELORS.value})
+        self.assertEqual(len(theses), num_matching_avail)
+        for thesis in theses:
+            self.assertEqual(thesis["kind"], ThesisKind.BACHELORS.value)
+            self.assertNotEqual(thesis["status"], ThesisStatus.IN_PROGRESS.value)
+            self.assertNotEqual(thesis["status"], ThesisStatus.DEFENDED.value)
+            self.assertIsNone(thesis["reserved_until"])
+
+    def test_ungraded_filter(self):
+        board_member = self.get_random_board_member()
+        _, ungraded_theses = self.create_theses_for_ungraded_testing(board_member)
+        self.login_as(board_member)
+        theses = self.get_theses_with_data({"type": ThesisTypeFilter.UNGRADED.value})
+        self.assertEqual(len(ungraded_theses), len(theses))
+        for graded in ungraded_theses:
+            self.assertTrue(exactly_one(recv_thesis["id"] == graded.pk for recv_thesis in theses))
+
+    def test_title_sort(self):
+        """Test that sorting by title works correctly"""
+        current_titles = ["abc", "abd", "def", "zzz"]
+        archived_titles = ["aaaa", "zyd"]
+        currents = [
+            self.make_thesis_nosave(title=cur_title, status=random_current_status())
+            for cur_title in current_titles
+        ]
+        archiveds = [
+            self.make_thesis_nosave(title=arch_title, status=ThesisStatus.DEFENDED)
+            for arch_title in archived_titles
+        ]
+        all_theses = currents + archiveds
+        Thesis.objects.bulk_create(random.sample(all_theses, len(all_theses)))
+        self.login_for_perms()
+        theses = self.get_theses_with_data({"column": "title", "dir": "asc"})
+        self.assertEqual(len(theses), len(all_theses))
+        all_titles = current_titles + archived_titles
+        for i in range(len(all_theses)):
+            self.assertEqual(theses[i]["title"], all_titles[i])
+
+    def test_advisor_sort(self):
+        """Test that sorting by advisor name works correctly"""
+        current_adv_names = ["abc", "abd", "def", "zzz"]
+        archived_adv_names = ["aaaa", "zyd"]
+        currents = [
+            self.make_thesis_nosave(
+                advisor=make_employee_with_name(cur_adv_name),
+                status=random_current_status()
+            ) for cur_adv_name in current_adv_names
+        ]
+        archiveds = [
+            self.make_thesis_nosave(
+                advisor=make_employee_with_name(arch_adv_name),
+                status=ThesisStatus.DEFENDED
+            ) for arch_adv_name in archived_adv_names
+        ]
+        all_theses = currents + archiveds
+        Thesis.objects.bulk_create(random.sample(all_theses, len(all_theses)))
+        self.login_for_perms()
+        theses = self.get_theses_with_data({"column": "advisor", "dir": "asc"})
+        self.assertEqual(len(theses), len(all_theses))
+        for i in range(len(all_theses)):
+            thesis_advisor = Employee.objects.get(pk=theses[i]["advisor"])
+            self.assertEqual(thesis_advisor, all_theses[i].advisor)

--- a/zapisy/apps/theses/tests/test_listing.py
+++ b/zapisy/apps/theses/tests/test_listing.py
@@ -1,0 +1,52 @@
+from typing import Optional
+
+from rest_framework import status
+from django.urls import reverse
+
+from apps.users.models import BaseUser
+from ..models import ThesisStatus
+from ..enums import NOT_READY_STATUSES
+from .base import ThesesBaseTestCase, PAGE_SIZE
+
+
+class ThesesListingTestCase(ThesesBaseTestCase):
+    """Tests theses listing functionality: is the limit setting respected,
+    are permissions granted correctly"""
+    @classmethod
+    def setUpTestData(cls):
+        super(ThesesListingTestCase, cls).setUpTestData()
+        cls.create_theses()
+
+    @classmethod
+    def create_theses(cls):
+        cls.num_theses = PAGE_SIZE
+        cls.theses = [cls.make_thesis() for _ in range(cls.num_theses)]
+
+    def _check_theses_response_data(self, data, expected_len: Optional[int]=None):
+        self.assertTrue(isinstance(data, dict))
+        self.assertTrue("count" in data)
+        self.assertTrue("results" in data)
+        results = data["results"]
+        self.assertTrue(isinstance(results, list))
+        self.assertEqual(len(results), PAGE_SIZE if expected_len is None else expected_len)
+
+    def _test_user_can_list_theses(self, user: BaseUser, expected_len: Optional[int]=None):
+        self.login_as(user)
+        response = self.get_response_with_data()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self._check_theses_response_data(response.data, expected_len)
+
+    def test_logged_in_can_list_theses(self):
+        self._test_user_can_list_theses(self.get_random_emp())
+        self._test_user_can_list_theses(self.get_random_board_member())
+        self._test_user_can_list_theses(self.get_admin())
+        # Students cannot see theses that are not "ready"
+        ready = list(filter(lambda t: ThesisStatus(t.status) not in NOT_READY_STATUSES, self.theses))
+        self._test_user_can_list_theses(
+            self.get_random_student(),
+            min(len(ready), PAGE_SIZE)
+        )
+
+    def test_logged_out_cannot_list_theses(self):
+        response = self.client.get(reverse("theses:theses-list"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/zapisy/apps/theses/tests/test_modification.py
+++ b/zapisy/apps/theses/tests/test_modification.py
@@ -1,0 +1,367 @@
+from rest_framework import status
+from django.urls import reverse
+
+from apps.users.models import Employee, BaseUser
+
+from ..models import (
+    ThesisStatus, ThesisVote,
+    MIN_REJECTION_REASON_LENGTH, MAX_REJECTION_REASON_LENGTH
+)
+from ..enums import UNVOTEABLE_STATUSES, NOT_READY_STATUSES
+from ..system_settings import get_num_required_votes
+from ..serializers import GenericDict
+from .base import ThesesBaseTestCase
+from .utils import (
+    random_vote, random_reserved_until,
+    accepting_vote, rejecting_vote, random_definite_vote,
+    string_of_length,
+)
+
+# Students shouldn't be allowed to modify any thesis regardless of status,
+# but depending on the status the error response will be different
+STUDENT_MODIFY_RESPONSES = [status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND]
+
+
+class ThesesModificationTestCase(ThesesBaseTestCase):
+    """Tests that theses modification via the REST API (PATCH requests)
+    and related processing work correctly
+    """
+    def setUp(self):
+        self.advisor = self.get_random_emp()
+        self.thesis = self.make_thesis(advisor=self.advisor, status=ThesisStatus.BEING_EVALUATED)
+
+    def update_thesis_with_data(self, **kwargs):
+        return self.client.patch(
+            f'{reverse("theses:theses-list")}{self.thesis.pk}/',
+            kwargs, format="json"
+        )
+
+    def get_modified_thesis(self):
+        """Re-fetch the thesis we're modifying from the backend code
+        There will always be only one instance as we create just one in setUp
+        """
+        return self.get_theses_with_data()[0]
+
+    def test_student_cannot_modify_thesis(self):
+        """Ensure that students are not permitted to modify theses"""
+        student = self.get_random_student()
+        self.login_as(student)
+        for thesis_status in ThesisStatus:
+            self.thesis.status = thesis_status.value
+            self.thesis.save()
+            response = self.update_thesis_with_data(reserved_until=random_reserved_until())
+            self.assertIn(response.status_code, STUDENT_MODIFY_RESPONSES)
+            if thesis_status not in NOT_READY_STATUSES:
+                # if not ready, it won't be sent back
+                modified_thesis = self.get_modified_thesis()
+                self.assertEqual(modified_thesis["reserved_until"], str(self.thesis.reserved_until))
+
+    def test_emp_can_modify_their_thesis(self):
+        """Ensure an employee can modify their own thesis, including changing the title
+        because the thesis is still being evaluated"""
+        self.login_as(self.advisor)
+        new_title = "Some new title"
+        new_desc = "Another description"
+        new_student = self.get_random_student()
+        response = self.update_thesis_with_data(
+            title=new_title, description=new_desc, students=[new_student.pk]
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        modified_thesis = self.get_modified_thesis()
+        self.assertEqual(modified_thesis["title"], new_title)
+        self.assertEqual(modified_thesis["description"], new_desc)
+        self.assertEqual(modified_thesis["students"][0]["id"], new_student.pk)
+
+    FROZEN_STATUSES = (
+        ThesisStatus.ACCEPTED,
+        ThesisStatus.IN_PROGRESS,
+    )
+
+    def _try_modify_frozen_with_data(self, **kwargs):
+        result = []
+        for frozen_status in ThesesModificationTestCase.FROZEN_STATUSES:
+            self.thesis.status = frozen_status.value
+            self.thesis.save()
+            result.append(self.update_thesis_with_data(**kwargs))
+        return result
+
+    def test_emp_cannot_modify_their_frozen_thesis_title(self):
+        """Ensure an employee cannot modify their thesis title if it's been "frozen" """
+        self.login_as(self.advisor)
+        new_title = "A new title"
+        responses = self._try_modify_frozen_with_data(title=new_title)
+        for response in responses:
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        modified_thesis = self.get_modified_thesis()
+        self.assertNotEqual(modified_thesis["title"], new_title)
+
+    def test_emp_can_modify_their_frozen_thesis_other_than_title(self):
+        """Ensure that modifying things other than title is permitted"""
+        self.login_as(self.advisor)
+        new_student_ids = list(map(lambda s: s.pk, self.get_random_students(2)))
+        responses = self._try_modify_frozen_with_data(students=new_student_ids)
+        for response in responses:
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+        modified_thesis = self.get_modified_thesis()
+        self.assertEqual(modified_thesis["students"][0]["id"], new_student_ids[0])
+        self.assertEqual(modified_thesis["students"][1]["id"], new_student_ids[1])
+
+    def test_emp_cannot_modify_someone_elses_thesis(self):
+        """Ensure that an employee cannot modify someone else's thesis"""
+        another_emp = self.get_random_emp_different_from(self.advisor)
+        self.login_as(another_emp)
+        new_desc = "Another description"
+        response = self.update_thesis_with_data(description=new_desc)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        modified_thesis = self.get_modified_thesis()
+        self.assertNotEqual(modified_thesis["description"], new_desc)
+
+    def test_board_member_can_modify_frozen_title(self):
+        """Ensure that board members are allowed to modify the title even if it's been "frozen" """
+        board_member = self.get_random_board_member()
+        self.login_as(board_member)
+        new_title = "A new title"
+        responses = self._try_modify_frozen_with_data(title=new_title)
+        for response in responses:
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+        modified_thesis = self.get_modified_thesis()
+        self.assertEqual(modified_thesis["title"], new_title)
+
+    def _try_modify_archived_as(self, user: BaseUser):
+        self.thesis.status = ThesisStatus.DEFENDED.value
+        self.thesis.save()
+        self.login_as(user)
+        return self.update_thesis_with_data(description="123")
+
+    def test_board_member_cannot_modify_archived(self):
+        """Ensure that board members (not admins) are not permitted to edit archived theses"""
+        response = self._try_modify_archived_as(self.get_random_board_member_not_admin())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_employee_cannot_modify_their_archived(self):
+        """Ensure that employees cannot modify their own theses (at all) if they're archived"""
+        response = self._try_modify_archived_as(self.advisor)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_can_modify_archived(self):
+        """Ensure that admins are permitted to modify archived theses"""
+        response = self._try_modify_archived_as(self.get_admin())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def cast_vote_as(self, voter: Employee, vote: GenericDict):
+        """Cast a vote for self.thesis of the specified value as the specified user"""
+        return self.update_thesis_with_data(votes={
+            voter.pk: {"value": vote["value"].value, "reason": vote.get("reason", "")}
+        })
+
+    def test_student_cannot_vote(self):
+        """Ensure that students are not permitted to vote"""
+        student = self.get_random_student()
+        self.login_as(student)
+        board_member = self.get_random_board_member()
+        for thesis_status in ThesisStatus:
+            self.thesis.status = thesis_status.value
+            self.thesis.save()
+            response = self.cast_vote_as(board_member, random_vote())
+            self.assertIn(response.status_code, STUDENT_MODIFY_RESPONSES)
+
+    def test_employee_cannot_vote(self):
+        """Ensure that employees are not permitted to vote"""
+        self.login_as(self.advisor)
+        board_member = self.get_random_board_member()
+        response = self.cast_vote_as(board_member, random_vote())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_board_members_can_vote_as_themselves(self):
+        """Ensure board members can vote, but only as themselves"""
+        board_member = self.get_random_board_member()
+        self.login_as(board_member)
+        response = self.cast_vote_as(board_member, random_vote())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_board_members_cannot_vote_as_other(self):
+        """Ensure board members cannot vote as anyone else"""
+        board_member = self.get_random_board_member_not_admin()
+        another_member = self.get_random_board_member_other_than([board_member])
+        self.login_as(board_member)
+        response = self.cast_vote_as(another_member, random_vote())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_can_vote_as_anyone(self):
+        """Ensure the system admin can cast votes as any board member"""
+        admin = self.get_admin()
+        another_member = self.get_random_board_member_not_admin()
+        self.login_as(admin)
+        response = self.cast_vote_as(another_member, random_vote())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_admin_cannot_cast_vote_as_non_board_member(self):
+        """Ensure that even the admin cannot vote as someone
+        who isn't a member of the theses board"""
+        admin = self.get_admin()
+        emp = self.get_random_emp()
+        self.login_as(admin)
+        response = self.cast_vote_as(emp, random_vote())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def _ensure_update_fails_with_400(self, **kwargs):
+        response = self.update_thesis_with_data(**kwargs)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def ensure_user_cannot_cast_invalid_vote(self, user: BaseUser):
+        self.login_as(user)
+        self._ensure_update_fails_with_400(votes="blah")
+        self._ensure_update_fails_with_400(votes={user.pk: "blah"})
+        self._ensure_update_fails_with_400(votes={user.pk: {"value": 123}})
+        reason_too_short = string_of_length(MIN_REJECTION_REASON_LENGTH - 10)
+        reason_too_long = string_of_length(MAX_REJECTION_REASON_LENGTH + 10)
+        self._ensure_update_fails_with_400(
+            votes={user.pk: {"value": ThesisVote.REJECTED.value, "reason": reason_too_short}}
+        )
+        self._ensure_update_fails_with_400(
+            votes={user.pk: {"value": ThesisVote.REJECTED.value, "reason": reason_too_long}}
+        )
+
+    def test_cannot_cast_invalid_vote(self):
+        self.run_test_with_board_members(self.ensure_user_cannot_cast_invalid_vote)
+
+    def vote_to_accept_thesis_required_times(
+        self, voter_to_skip: Employee = None, as_admin: bool = False
+    ):
+        """Cast enough approving votes to accept the current thesis, not using
+        the specified voter (if specified)
+        """
+        num_required = get_num_required_votes()
+        self.assertLessEqual(num_required, len(self.board_members))
+        voters = self.get_board_members(num_required, voter_to_skip)
+        for voter in voters:
+            self.login_as(self.get_admin() if as_admin else voter)
+            response = self.cast_vote_as(voter, accepting_vote())
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_enough_votes_accept_thesis(self):
+        """Test that when enough board members vote "approve" on a thesis, it gets accepted"""
+        self.thesis.set_students([])
+        self.thesis.save()
+        self.vote_to_accept_thesis_required_times()
+        modified_thesis = self.get_modified_thesis()
+        self.assertEqual(modified_thesis["status"], ThesisStatus.ACCEPTED.value)
+
+    def reject_thesis_once(self, voter: Employee):
+        """Cast a rejecting vote for the current thesis as the given voter"""
+        self.login_as(voter)
+        response = self.cast_vote_as(voter, rejecting_vote())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_single_rejection_doesnt_reject_thesis(self):
+        """Ensure that a single rejection doesn't reject a thesis"""
+        self.reject_thesis_once(self.get_random_board_member())
+        modified_thesis = self.get_modified_thesis()
+        self.assertNotEqual(modified_thesis["status"], ThesisStatus.RETURNED_FOR_CORRECTIONS.value)
+
+    def test_enough_votes_do_accept_after_rejection(self):
+        """Ensure that if a thesis was rejected, it will be accepted again if
+        enough "approve" votes are cast
+        """
+        self.thesis.set_students([])
+        self.thesis.save()
+        rejecter = self.get_random_board_member()
+        self.reject_thesis_once(rejecter)
+        self.vote_to_accept_thesis_required_times(rejecter)
+        modified_thesis = self.get_modified_thesis()
+        self.assertEqual(modified_thesis["status"], ThesisStatus.ACCEPTED.value)
+
+    def test_cannot_vote_for_vote_unchangeable(self):
+        """Test that employees are not permitted to vote for "vote unchangeable" theses"""
+        voter = self.get_random_board_member_not_admin()
+        self.login_as(voter)
+        for thesis_status in UNVOTEABLE_STATUSES:
+            self.thesis.status = thesis_status.value
+            self.thesis.save()
+            response = self.cast_vote_as(voter, random_definite_vote())
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def _vote_then_change_title_as_user(self, user: BaseUser):
+        self.cast_vote_as(self.get_random_board_member(), accepting_vote())
+        self.reject_thesis_once(self.get_random_board_member())
+        self.login_as(user)
+        self.update_thesis_with_data(title="lol123")
+
+    def test_emp_editing_their_thesis_title_wipes_votes(self):
+        """Votes should be wiped when the advisor of a thesis modifies the title"""
+        self._vote_then_change_title_as_user(self.advisor)
+        self.assertEqual(self.thesis.votes.count(), 0)
+
+    def test_board_member_editing_thesis_title_doesnt_wipe_votes(self):
+        """Votes should not be wiped if it's a board member making the change"""
+        self._vote_then_change_title_as_user(self.get_random_board_member_not_admin())
+        self.assertGreater(self.thesis.votes.count(), 0)
+
+    def test_admin_editing_thesis_title_doesnt_wipe_votes(self):
+        """Votes should not be wiped if it's an admin making the change"""
+        self._vote_then_change_title_as_user(self.get_admin())
+        self.assertGreater(self.thesis.votes.count(), 0)
+
+    def _vote_as_temp_board_member(self):
+        temp_board_member = self.get_random_emp()
+        self.board_group.user_set.add(temp_board_member.user)
+        self.set_thesis_vote_locally(self.thesis, temp_board_member, accepting_vote())
+        self.board_group.user_set.remove(temp_board_member.user)
+        return temp_board_member
+
+    def test_admin_can_modify_previous_board_members_vote(self):
+        """Ensure that admins have the right to modify votes cast by previous board members"""
+        temp_board_member = self._vote_as_temp_board_member()
+        self.login_as(self.get_admin())
+        response = self.cast_vote_as(temp_board_member, rejecting_vote())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_previous_board_member_cannot_modify_their_vote(self):
+        temp_board_member = self._vote_as_temp_board_member()
+        self.login_as(temp_board_member)
+        response = self.cast_vote_as(temp_board_member, rejecting_vote())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def ensure_cannot_modify_thesis_duplicate_title_as_user(self, user: BaseUser):
+        other_thesis = self.make_thesis()
+        padded_title = f'\n\t   {other_thesis.title}   \t\t\n       '
+        self.login_as(user)
+        response = self.update_thesis_with_data(title=padded_title)
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_cannot_modify_thesis_duplicate_title(self):
+        """Test that a thesis cannot be modified to contain a duplicate title by any user"""
+        self.run_test_with_board_members(
+            self.ensure_cannot_modify_thesis_duplicate_title_as_user
+        )
+        self.ensure_cannot_modify_thesis_duplicate_title_as_user(self.advisor)
+
+    def test_board_member_cannot_reject(self):
+        """Ensure that no one but the rejecter can reject a thesis"""
+        member = self.get_random_board_member_not_admin_or_rejecter()
+        self.login_as(member)
+        response = self.update_thesis_with_data(status=ThesisStatus.RETURNED_FOR_CORRECTIONS.value)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_rejecter_can_reject_thesis(self):
+        self.login_as(self.get_rejecter())
+        response = self.update_thesis_with_data(status=ThesisStatus.RETURNED_FOR_CORRECTIONS.value)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def ensure_cannot_set_invalid_status_as_user(self, user: BaseUser):
+        self.login_as(user)
+        response = self.update_thesis_with_data(status=123)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_cannot_set_invalid_status(self):
+        self.run_test_with_board_members(self.ensure_cannot_set_invalid_status_as_user)
+        self.ensure_cannot_set_invalid_status_as_user(self.advisor)
+
+    def ensure_cannot_set_invalid_kind_as_user(self, user: BaseUser):
+        self.login_as(user)
+        response = self.update_thesis_with_data(kind=123)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_cannot_set_invalid_kind(self):
+        self.run_test_with_board_members(self.ensure_cannot_set_invalid_kind_as_user)
+        self.ensure_cannot_set_invalid_kind_as_user(self.advisor)

--- a/zapisy/apps/theses/tests/test_modification.py
+++ b/zapisy/apps/theses/tests/test_modification.py
@@ -14,7 +14,7 @@ from .base import ThesesBaseTestCase
 from .utils import (
     random_vote, random_reserved_until,
     accepting_vote, rejecting_vote, random_definite_vote,
-    string_of_length,
+    string_of_length, exactly_one
 )
 
 # Students shouldn't be allowed to modify any thesis regardless of status,
@@ -103,8 +103,13 @@ class ThesesModificationTestCase(ThesesBaseTestCase):
         for response in responses:
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         modified_thesis = self.get_modified_thesis()
-        self.assertEqual(modified_thesis["students"][0]["id"], new_student_ids[0])
-        self.assertEqual(modified_thesis["students"][1]["id"], new_student_ids[1])
+        for new_stud_id in new_student_ids:
+            self.assertTrue(
+                exactly_one(
+                    recv_student["id"] == new_stud_id
+                    for recv_student in modified_thesis["students"]
+                )
+            )
 
     def test_emp_cannot_modify_someone_elses_thesis(self):
         """Ensure that an employee cannot modify someone else's thesis"""

--- a/zapisy/apps/theses/tests/test_other_endpoints.py
+++ b/zapisy/apps/theses/tests/test_other_endpoints.py
@@ -1,0 +1,159 @@
+from typing import List
+import json
+
+from rest_framework import status
+from django.urls import reverse
+
+from apps.users.models import BaseUser, Employee
+from ..users import get_theses_user_full_name
+from ..enums import ThesisUserType
+from .base import ThesesBaseTestCase
+from .utils import make_employee_with_name, make_student_with_name, exactly_one
+
+
+class OtherEndpointsTestCase(ThesesBaseTestCase):
+    """Tests remaining endpoints - current user, num ungraded, autocomplete etc"""
+
+    def test_theses_board_denied_for_not_logged_in(self):
+        """Ensure that unauthenticated users are not permitted to query about the theses board"""
+        response = self.client.get(reverse("theses:theses_board-list"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def _test_theses_board_ok_for_user(self, user: BaseUser):
+        """Ensure the specified user can access the theses board and gets correct results"""
+        self.login_as(user)
+        response = self.client.get(reverse("theses:theses_board-list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(self.board_members), len(data))
+        for member in self.board_members:
+            self.assertTrue(exactly_one(recvd_member == member.pk for recvd_member in data))
+
+    def test_theses_board_ok_for_logged_in(self):
+        """Ensure that logged in users of various types can access the theses board"""
+        self._test_theses_board_ok_for_user(self.get_random_emp())
+        self._test_theses_board_ok_for_user(self.get_random_student())
+        self._test_theses_board_ok_for_user(self.get_random_board_member())
+
+    def test_theses_employees_denied_for_not_logged_in(self):
+        """Ensure that unauthenticated users are not permitted to query about the employees"""
+        response = self.client.get(reverse("theses:theses_employees-list"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def _test_theses_employees_ok_for_user(self, user: BaseUser):
+        """Ensure that the "get all employees" endpoint works correctly"""
+        self.login_as(user)
+        response = self.client.get(reverse("theses:theses_employees-list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertIsInstance(data, list)
+        self.assertEqual(Employee.objects.count(), len(data))
+        for recvd_emp in data:
+            emp = Employee.objects.get(pk=recvd_emp["id"])
+            self.assertEqual(emp.user.username, recvd_emp["username"])
+            self.assertEqual(get_theses_user_full_name(emp), recvd_emp["name"])
+
+    def test_theses_employees_ok_for_logged_in(self):
+        """Ensure that logged in users of various types can access the employees list"""
+        self._test_theses_employees_ok_for_user(self.get_random_emp())
+        self._test_theses_employees_ok_for_user(self.get_random_student())
+        self._test_theses_employees_ok_for_user(self.get_random_board_member())
+
+    def test_current_user_endpoint_denied_for_logged_in(self):
+        """Ensure that unauthenticated users cannot access the current user endpoint"""
+        response = self.client.get(reverse("theses:current_user"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def _test_current_user_for_user(self, user: BaseUser, expected_type: ThesisUserType):
+        self.login_as(user)
+        response = self.client.get(reverse("theses:current_user"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["type"], expected_type.value)
+        self.assertEqual(data["person"]["id"], user.pk)
+        self.assertEqual(data["person"]["name"], user.get_full_name())
+
+    def test_current_user_endpoint_ok_for_logged_in(self):
+        """Ensure the current user endpoint returns correct data for each possible
+        type of user
+        """
+        self._test_current_user_for_user(self.get_admin(), ThesisUserType.ADMIN)
+        self._test_current_user_for_user(self.get_random_emp(), ThesisUserType.REGULAR_EMPLOYEE)
+        self._test_current_user_for_user(self.get_random_student(), ThesisUserType.STUDENT)
+
+    def test_autocomplete_denied_for_not_logged_in(self):
+        """Ensure users that are not logged in cannot access the student/emp
+        autocomplete endpoint. This is important as these endpoints return
+        lists containing both names and user IDs
+        """
+        response = self.client.get(reverse("theses:theses_ac_students-list"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        response = self.client.get(reverse("theses:theses_ac_employees-list"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def _test_autocomplete_filtering(
+        self, url: str, matching_users: List[BaseUser], search_filter: str
+    ):
+        response = self.client.get(url, {"filter": search_filter})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = json.loads(response.content)
+        results = data["results"]
+        self.assertEqual(len(results), len(matching_users))
+        for matching_user in matching_users:
+            self.assertTrue(exactly_one(
+                int(recvd_user["id"]) == matching_user.pk and
+                recvd_user["name"] == get_theses_user_full_name(matching_user)
+                for recvd_user in results)
+            )
+
+    def test_autocomplete_allowed_and_filtered_for_logged_in(self):
+        """Ensure logged in users can download the autocomplete list
+        and that it's correctly filtered
+        """
+        emp = self.get_random_emp()
+        self.login_as(emp)
+
+        matching_emp_names = ["abc", "abces"]
+        nonmatching_emp_names = ["abdec", "xyz"]
+        matching_emps = [make_employee_with_name(name) for name in matching_emp_names]
+        for name in nonmatching_emp_names:
+            make_employee_with_name(name)
+        self._test_autocomplete_filtering(
+            reverse("theses:theses_ac_employees-list"), matching_emps, "abc"
+        )
+
+        matching_stud_names = ["foo", "foobar"]
+        nonmatching_stud__names = ["other", "quux"]
+        matching_emps = [make_student_with_name(name) for name in matching_stud_names]
+        for name in nonmatching_stud__names:
+            make_student_with_name(name)
+        self._test_autocomplete_filtering(
+            reverse("theses:theses_ac_students-list"), matching_emps, "foo"
+        )
+
+    def test_num_ungraded_denied_for_not_logged_in(self):
+        """Ensure that unauthenticated users cannot access the num ungraded endpoint"""
+        response = self.client.get(reverse("theses:num_ungraded"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def get_num_ungraded_response_for_user(self, user: BaseUser) -> int:
+        self.login_as(user)
+        return self.client.get(reverse("theses:num_ungraded"))
+
+    def test_num_ungraded_ok_for_board_member(self):
+        """Ensure that the num ungraded endpoint works correctly for board members"""
+        board_member = self.get_random_board_member()
+        _, ungraded_theses = self.create_theses_for_ungraded_testing(board_member)
+        response = self.get_num_ungraded_response_for_user(board_member)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, len(ungraded_theses))
+
+    def test_num_ungraded_returns_404_for_non_board_member(self):
+        """Ensure that if a user that isn't a board member makes a num ungraded request,
+        they get a 404 error"""
+        response = self.get_num_ungraded_response_for_user(self.get_random_emp())
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        response = self.get_num_ungraded_response_for_user(self.get_random_student())
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/zapisy/apps/theses/tests/test_serialization.py
+++ b/zapisy/apps/theses/tests/test_serialization.py
@@ -1,0 +1,79 @@
+import random
+
+from apps.users.models import BaseUser
+
+from ..models import ThesisStatus
+from .base import ThesesBaseTestCase
+from .utils import random_definite_vote, exactly_one
+
+
+class ThesesSerializationTestCase(ThesesBaseTestCase):
+    """Basic tests to ensure thesis serialization works correctly"""
+    def setUp(self):
+        self.advisor = self.get_random_emp()
+        self.thesis = self.make_thesis(advisor=self.advisor, status=ThesisStatus.ACCEPTED)
+
+    def get_serialized_thesis(self):
+        return self.get_theses_with_data()[0]
+
+    def test_basic_fields_serialized_correctly(self):
+        self.login_as(self.get_random_emp())
+        thesis = self.get_serialized_thesis()
+        self.assertEqual(thesis["title"], self.thesis.title)
+        self.assertEqual(thesis["advisor"], self.advisor.pk)
+        self.assertEqual(
+            thesis["supporting_advisor"],
+            self.thesis.supporting_advisor.pk if self.thesis.supporting_advisor else None
+        )
+        self.assertEqual(thesis["kind"], self.thesis.kind)
+        self.assertEqual(thesis["status"], self.thesis.status)
+        self.assertEqual(
+            thesis["reserved_until"],
+            str(self.thesis.reserved_until) if self.thesis.reserved_until else None
+        )
+        self.assertEqual(thesis["description"], self.thesis.description)
+        num_serialized_students = len(thesis["students"])
+        self.assertEqual(num_serialized_students, self.thesis.students.count())
+        for i in range(num_serialized_students):
+            self.assertEqual(thesis["students"][i]["id"], self.thesis.get_students()[i].pk)
+
+    def _get_thesis_with_votes(self, user: BaseUser):
+        board_members = self.get_board_members(random.randint(2, 5))
+        temp_board_member = self.get_random_emp()
+        # Also add a vote by a previous board member to check that too
+        self.board_group.user_set.add(temp_board_member.user)
+        votes = [(member, random_definite_vote()) for member in board_members]
+        votes.append((temp_board_member, random_definite_vote()))
+        self.board_group.user_set.remove(temp_board_member.user)
+        for voter, vote in votes:
+            self.set_thesis_vote_locally(self.thesis, voter, vote)
+        self.login_as(user)
+        thesis = self.get_serialized_thesis()
+        return thesis, votes
+
+    def _test_no_votes_for(self, user: BaseUser):
+        thesis, _ = self._get_thesis_with_votes(user)
+        self.assertNotIn("votes", thesis)
+
+    def test_vote_counts_for_student(self):
+        self._test_no_votes_for(self.get_random_student())
+
+    def test_vote_counts_for_emp(self):
+        self._test_no_votes_for(self.get_random_emp())
+
+    def _test_vote_details_for(self, user: BaseUser):
+        thesis, votes = self._get_thesis_with_votes(user)
+        self.assertIn("votes", thesis)
+        votes_dict = thesis["votes"]
+        self.assertEqual(len(set(votes_dict.keys())), len(votes))
+        for voter_id, vote_details in votes_dict.items():
+            vote_value = vote_details["value"]
+            self.assertTrue(
+                exactly_one((m.pk == voter_id and v["value"].value == vote_value for m, v in votes))
+            )
+
+    def test_vote_details_for_board_member(self):
+        self._test_vote_details_for(self.get_random_board_member_not_admin())
+
+    def test_vote_details_for_admin(self):
+        self._test_vote_details_for(self.get_admin())

--- a/zapisy/apps/theses/tests/test_serialization.py
+++ b/zapisy/apps/theses/tests/test_serialization.py
@@ -34,8 +34,13 @@ class ThesesSerializationTestCase(ThesesBaseTestCase):
         self.assertEqual(thesis["description"], self.thesis.description)
         num_serialized_students = len(thesis["students"])
         self.assertEqual(num_serialized_students, self.thesis.students.count())
-        for i in range(num_serialized_students):
-            self.assertEqual(thesis["students"][i]["id"], self.thesis.get_students()[i].pk)
+        for student in self.thesis.get_students():
+            self.assertTrue(
+                exactly_one(
+                    recv_student["id"] == student.pk
+                    for recv_student in thesis["students"]
+                )
+            )
 
     def _get_thesis_with_votes(self, user: BaseUser):
         board_members = self.get_board_members(random.randint(2, 5))

--- a/zapisy/apps/theses/tests/utils.py
+++ b/zapisy/apps/theses/tests/utils.py
@@ -1,0 +1,118 @@
+import random
+import sys
+from typing import List, Any
+from datetime import date, timedelta
+from string import ascii_uppercase
+
+from faker import Faker
+
+from apps.users.models import Employee, Student
+from apps.users.tests.factories import EmployeeFactory, StudentFactory
+from ..models import ThesisKind, ThesisStatus, ThesisVote, VoteToProcess, MIN_REJECTION_REASON_LENGTH
+
+
+fake = Faker()
+
+
+def random_bool():
+    return bool(random.getrandbits(1))
+
+
+def random_title():
+    """Return a unique random title"""
+    return f'{fake.name()}_{random.randrange(sys.maxsize)}'
+
+
+def random_advisor(emps):
+    return random.choice(emps)
+
+
+def random_kind():
+    return random.choice(list(ThesisKind))
+
+
+def random_status():
+    return random.choice([status for status in ThesisStatus])
+
+
+def random_current_status():
+    """Return a random "current", i.e. not defended status"""
+    return random.choice([status for status in ThesisStatus if status != ThesisStatus.DEFENDED])
+
+
+def random_available_status():
+    """Return a random status where the thesis will be considered "available"
+    for students
+    """
+    return random.choice([
+        ThesisStatus.ACCEPTED,
+        ThesisStatus.BEING_EVALUATED,
+        ThesisStatus.RETURNED_FOR_CORRECTIONS
+    ])
+
+
+def random_reserved_until():
+    return date.today() + timedelta(days=random.randrange(100))
+
+
+def random_description():
+    return fake.text()
+
+
+def random_student(studs):
+    return random.choice(studs)
+
+
+def random_vote_from_list(l: List[ThesisVote]):
+    vote_value = random.choice(l)
+    return {
+        "value": vote_value,
+        "reason": random_rejection_reason() if vote_value == ThesisVote.REJECTED else ""
+    }
+
+
+def random_vote():
+    return random_vote_from_list(list(ThesisVote))
+
+
+def random_definite_vote():
+    """Return a random thesis vote other than none"""
+    return random_vote_from_list([
+        ThesisVote.ACCEPTED,
+        ThesisVote.REJECTED,
+    ])
+
+
+def accepting_vote():
+    return {"value": ThesisVote.ACCEPTED}
+
+
+def rejecting_vote():
+    return {
+        "value": ThesisVote.REJECTED,
+        "reason": random_rejection_reason()
+    }
+
+
+def random_rejection_reason():
+    result = fake.text()
+    while len(result) < MIN_REJECTION_REASON_LENGTH:
+        result += fake.text()
+    return result
+
+
+def make_employee_with_name(name: str) -> Employee:
+    return EmployeeFactory(user__first_name=name, user__last_name="")
+
+
+def make_student_with_name(name: str) -> Student:
+    return StudentFactory(user__first_name=name, user__last_name="")
+
+
+def exactly_one(l: List[Any]) -> bool:
+    """Check that exactly one element in the list is truthy"""
+    return sum(bool(e) for e in l) == 1
+
+
+def string_of_length(length: int) -> str:
+    return "".join(random.choice(ascii_uppercase) for i in range(length))

--- a/zapisy/apps/users/tests/factories.py
+++ b/zapisy/apps/users/tests/factories.py
@@ -22,6 +22,8 @@ class UserFactory(DjangoModelFactory):
     suff_username = ""
     username = factory.LazyAttribute(lambda o: o.pref_username + o.suff_username)
     password = factory.PostGenerationMethodCall('set_password', 'test')
+    first_name = 'user'
+    last_name = factory.LazyAttributeSequence(lambda o, n: f'{n}{o.suff_username}')
     is_staff = False
     is_superuser = False
     email = factory.LazyAttribute(lambda o: o.pref_username + o.suff_username + '@example.com')

--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import logging
 import environ
 from django.contrib.messages import constants as messages
@@ -12,6 +13,7 @@ environ.Env.read_env(os.path.join(BASE_DIR, os.pardir, 'env', '.env'))
 
 DEBUG = env.bool('DEBUG')
 RELEASE = env.bool('RELEASE')
+TESTING = sys.argv[1:2] == ["test"]
 
 # With DEBUG = False Django will refuse to serve requests to hosts different than this one.
 ALLOWED_HOSTS = env.list('ALLOWED_HOSTS')
@@ -356,6 +358,17 @@ CACHES = {
         'TIMEOUT': 300,
     }
 }
+
+# When testing, don't use strong hashers that take forever to compute
+# Taken from https://github.com/FactoryBoy/factory_boy/issues/224
+# This very noticeably improves performance when creating multiple test users
+# (by an order of magnitude, for ~40 users 30 sec -> 1 sec)
+# We very much don't want this to ever happen in a productive environment,
+# so also check for RELEASE
+if TESTING and not RELEASE:
+    PASSWORD_HASHERS = (
+        'django.contrib.auth.hashers.UnsaltedMD5PasswordHasher',
+    )
 
 NEWS_PER_PAGE = 15
 


### PR DESCRIPTION
PR dodaje testy backendu systemu prac dyplomowych. Potrzebne do tego były dwie zmiany związane z fabrykami userów z `apps.users.tests.factories`:
* nie były ustawiane pola `first_name` i `last_name` na userze - wydaje się, że fabryka usera nie działa do końca poprawnie, jeżeli ich nie ustawia, a były mi potrzebne do filtrowania, więc je dodałem
* tworzenie userów było _bardzo_ powolne przez silne funkcje hashujące używane przy tworzeniu/sprawdzaniu haseł; mocne przyspieszenie daje przestawienie hashera na słabe md5, oczywiście *tylko przy testowaniu*