### PR TITLE
Travis - szybsza konfiguracja

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,6 @@ before_script:
   - mv env/.env_travis env/.env
   - mkdir zapisy/logs
 
-# Run scripts specified in Jobs rather than one global script.
-script: true
-
 jobs:
   include:
     - stage: lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - ls -la /home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages
   - pip install -r zapisy/requirements.test.txt
   # Installs Yarn/NPM dependencies.
-  - cd zapisy && ls -la node_modules && cd ..
+  - cd zapisy && ls -la node_modules || true && cd ..
   - cd zapisy && yarn && cd ..
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
 install:
   - pip install -r zapisy/requirements.test.txt
   # Installs Yarn/NPM dependencies.
-  - cd zapisy && yarn
+  - cd zapisy && yarn && cd ..
 
 before_script:
   - psql -c 'CREATE DATABASE fereol_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,8 @@ services:
   - postgresql
 
 install:
-  - ls -la /home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages
   - pip install -r zapisy/requirements.test.txt
   # Installs Yarn/NPM dependencies.
-  - cd zapisy && ls -la node_modules || true && cd ..
   - cd zapisy && yarn && cd ..
 
 before_script:
@@ -34,6 +32,9 @@ script: |
   python -m flake8 --statistics --ignore=E265,E501,F401,F841 --exclude=node_modules,*migrations --max-line-length 120 .
   cd zapisy
   yarn build
+  # Don't store the build cache; it changes after each build, Travis then
+  # picks that change up and repacks the cache archive which takes forever
+  rm -rf node_modules/.cache-loader-*
   python manage.py test apps --failfast --parallel
 
 cache:
@@ -46,6 +47,8 @@ cache:
     # where the branch is switched and packages need to be added; then the cache
     # above can be used
     - zapisy/node_modules
+    # Cache the virtualenv packages folder so virtualenv doesn't waste
+    # installing locally cached packages
     - "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,18 +28,15 @@ before_script:
   - mv env/.env_travis env/.env
   - mkdir zapisy/logs
 
-jobs:
-  include:
-    - stage: lint
-    - script: flake8 --statistics --ignore=E265,E501,F401,F841 --exclude=node_modules,*migrations --max-line-length 120 .
-
-    - stage: test
-    - script: cd zapisy && python manage.py test apps.news.tests --nomigrations
-    - script: cd zapisy && python manage.py test apps.schedule --nomigrations
-    - script: cd zapisy && python manage.py test apps.enrollment.courses --nomigrations
-    - script: cd zapisy && python manage.py test apps.enrollment.records.tests --nomigrations
-    - script: cd zapisy && python manage.py test apps.grade.poll --nomigrations
-    - script: cd zapisy && python manage.py test apps.users --nomigrations
+# Run scripts specified in Jobs rather than one global script.
+script: |
+  flake8 --statistics --ignore=E265,E501,F401,F841 --exclude=node_modules,*migrations --max-line-length 120 .
+  python manage.py test apps.news.tests --nomigrations
+  python manage.py test apps.schedule --nomigrations
+  python manage.py test apps.enrollment.courses --nomigrations
+  python manage.py test apps.enrollment.records.tests --nomigrations
+  python manage.py test apps.grade.poll --nomigrations
+  python manage.py test apps.users --nomigrations
 
 cache:
 - pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ cache:
     # And this caches the packages themselves, so we don't spend time installing
     # them unnecesarily. This mostly supersedes the option above, except cases
     # where the branch is switched and packages need to be added; then the cache
-    # above can be used.
+    # above can be used
     - zapisy/node_modules
     - "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
 # Run scripts specified in Jobs rather than one global script.
 script: |
   flake8 --statistics --ignore=E265,E501,F401,F841 --exclude=node_modules,*migrations --max-line-length 120 .
+  cd zapisy
   python manage.py test apps.news.tests --nomigrations
   python manage.py test apps.schedule --nomigrations
   python manage.py test apps.enrollment.courses --nomigrations

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_script:
 
 # Run scripts specified in Jobs rather than one global script.
 script: |
+  set -e
   flake8 --statistics --ignore=E265,E501,F401,F841 --exclude=node_modules,*migrations --max-line-length 120 .
   cd zapisy
   python manage.py test apps.news.tests --nomigrations
@@ -42,6 +43,8 @@ script: |
 cache:
 - pip
 - yarn
+directories:
+  - zapisy/node_modules
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - ls -la /home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages
   - pip install -r zapisy/requirements.test.txt
   # Installs Yarn/NPM dependencies.
-  - ls -la node_modules
+  - cd zapisy && ls -la node_modules && cd ..
   - cd zapisy && yarn && cd ..
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ script: |
   python manage.py test apps --failfast --parallel
 
 cache:
-- pip
-# This caches yarn/.cache, which mostly means we don't need to redownload packages
-- yarn
-  directories:
+  - pip
+  # This caches yarn/.cache, which mostly means we don't need to redownload packages
+  - yarn
+  - directories:
     # And this caches the packages themselves, so we don't spend time installing
     # them unnecesarily. This mostly supersedes the option above, except cases
     # where the branch is switched and packages need to be added; then the cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,13 @@ cache:
 - pip
 # This caches yarn/.cache, which mostly means we don't need to redownload packages
 - yarn
-directories:
-  # And this caches the packages themselves, so we don't spend time installing
-  # them unnecesarily. This mostly supersedes the option above, except cases
-  # where the branch is switched and packages need to be added; then the cache
-  # above can be used.
-  - zapisy/node_modules
-  - "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages"
+  directories:
+    # And this caches the packages themselves, so we don't spend time installing
+    # them unnecesarily. This mostly supersedes the option above, except cases
+    # where the branch is switched and packages need to be added; then the cache
+    # above can be used.
+    - zapisy/node_modules
+    - "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,31 +19,30 @@ services:
 install:
   - pip install -r zapisy/requirements.test.txt
   # Installs Yarn/NPM dependencies.
-  - cd zapisy && yarn && cd ..
-  # Builds assets.
-  - cd zapisy && yarn build && cd ..
+  - cd zapisy && yarn
 
 before_script:
   - psql -c 'CREATE DATABASE fereol_test;' -U postgres
   - mv env/.env_travis env/.env
   - mkdir zapisy/logs
 
-# Run scripts specified in Jobs rather than one global script.
+# Lint, build frontend dependencies, run Django tests
 script: |
   set -e
   flake8 --statistics --ignore=E265,E501,F401,F841 --exclude=node_modules,*migrations --max-line-length 120 .
   cd zapisy
-  python manage.py test apps.news.tests --nomigrations
-  python manage.py test apps.schedule --nomigrations
-  python manage.py test apps.enrollment.courses --nomigrations
-  python manage.py test apps.enrollment.records.tests --nomigrations
-  python manage.py test apps.grade.poll --nomigrations
-  python manage.py test apps.users --nomigrations
+  yarn build
+  python manage.py test apps --failfast --parallel
 
 cache:
 - pip
+# This caches yarn/.cache, which mostly means we don't need to redownload packages
 - yarn
 directories:
+  # And this caches the packages themselves, so we don't spend time installing
+  # them unnecesarily. This mostly supersedes the option above, except cases
+  # where the branch is switched and packages need to be added; then the cache
+  # above can be used.
   - zapisy/node_modules
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - ls -la /home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages
   - pip install -r zapisy/requirements.test.txt
   # Installs Yarn/NPM dependencies.
+  - ls -la node_modules
   - cd zapisy && yarn && cd ..
 
 before_script:
@@ -32,7 +33,6 @@ script: |
   set -e
   flake8 --statistics --ignore=E265,E501,F401,F841 --exclude=node_modules,*migrations --max-line-length 120 .
   cd zapisy
-  ls -la node_modules
   yarn build
   python manage.py test apps --failfast --parallel
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ services:
   - postgresql
 
 install:
+  - ls -la /home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages
   - pip install -r zapisy/requirements.test.txt
   # Installs Yarn/NPM dependencies.
   - cd zapisy && yarn && cd ..
@@ -31,6 +32,7 @@ script: |
   set -e
   flake8 --statistics --ignore=E265,E501,F401,F841 --exclude=node_modules,*migrations --max-line-length 120 .
   cd zapisy
+  ls -la node_modules
   yarn build
   python manage.py test apps --failfast --parallel
 
@@ -44,6 +46,7 @@ directories:
   # where the branch is switched and packages need to be added; then the cache
   # above can be used.
   - zapisy/node_modules
+  - "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
 # Lint, build frontend dependencies, run Django tests
 script: |
   set -e
-  flake8 --statistics --ignore=E265,E501,F401,F841 --exclude=node_modules,*migrations --max-line-length 120 .
+  python -m flake8 --statistics --ignore=E265,E501,F401,F841 --exclude=node_modules,*migrations --max-line-length 120 .
   cd zapisy
   yarn build
   python manage.py test apps --failfast --parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ cache:
     # above can be used
     - zapisy/node_modules
     # Cache the virtualenv packages folder so virtualenv doesn't waste
-    # installing locally cached packages
+    # time installing locally cached packages
     - "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages"
 
 notifications:

--- a/zapisy/apps/grade/ticket_create/legacy_tests.py
+++ b/zapisy/apps/grade/ticket_create/legacy_tests.py
@@ -1,3 +1,6 @@
+"""Some of the following tests have not been updated
+and do not work, so they have been disabled by renaming this file
+"""
 from django.test import TestCase
 from .utils import generate_keys_for_polls, group_polls_by_course
 from apps.grade.poll.models import Poll

--- a/zapisy/apps/offer/vote/legacy_tests.py
+++ b/zapisy/apps/offer/vote/legacy_tests.py
@@ -1,3 +1,6 @@
+"""Some of the following tests have not been updated
+and do not work, so they have been disabled by renaming this file
+"""
 from django.test import TestCase
 from django.utils import timezone
 from django.urls import reverse

--- a/zapisy/zapisy/urls.py
+++ b/zapisy/zapisy/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
     url(r'^records/', include('apps.enrollment.records.urls')),
     url(r'^statistics/', include(('apps.statistics.urls', 'statistics'), namespace='statistics')),
     url(r'^consultations/$', users_views.consultations_list, name="consultations-list"),
- 
+
     url(r'^news/', include('apps.news.urls')),
     url(r'^jstests/', TemplateView.as_view(template_name="jstests/tests.html")),
     url(r'^users/', include('apps.users.urls')),


### PR DESCRIPTION
Proponuję taką wersję konfiguracji Travisa. Zmiany:
* uruchamianie `./manage.py test apps` zamiast wszystkiego osobno; dzięki temu migracje aplikowane są raz (to jest powolny proces, około 20 sekund), a nie per aplikacja. Żeby to osiągnąć, trzeba było wyłączyć niedziałające i nieużywane testy aplikacji `offer.vote` i `grade.ticket_create`.
* agresywna polityka cache'owania paczek Pythonowych i Node'owych - ich instalacja zajmuje łącznie ok. 40 sekund, nawet ze standardowym cache'em travisa. Tutaj cache'ujemy już zainstalowane paczki, dzięki czemu instalacja nie zajmuje w ogóle czasu