### PR TITLE
Fixes is_after_t0 crash when closing time unspecified.

### DIFF
--- a/zapisy/apps/enrollment/records/models/opening_times.py
+++ b/zapisy/apps/enrollment/records/models/opening_times.py
@@ -43,7 +43,7 @@ class T0Times(models.Model):
         """
         if not student.is_active():
             return False
-        if time > semester.records_closing:
+        if semester.records_closing is not None and time > semester.records_closing:
             return False
         t0_record = None
         try:


### PR DESCRIPTION
Jeśli semestr nie ma ustawionego `records_closing` (czasu zamknięcia zapisów), sprawdzanie, czy zapis do grupy jest dozwolony nie powinno rzucać wyjątków.

Fixes #618 