### PR TITLE
Warns when enrollment will not happen.

### DIFF
--- a/zapisy/apps/enrollment/records/views.py
+++ b/zapisy/apps/enrollment/records/views.py
@@ -29,6 +29,11 @@ def enqueue(request):
                 "asynchroniczny proces."
             )
         )
+        if not Record.can_enroll(student, group):
+            messages.warning(request,
+                             ("W tym momencie nie spełniasz kryteriów zapisu do tej grupy. "
+                              "Jeśli nie  zmieni się to do czasu wciągania Twojego rekordu "
+                              "z  kolejki, zostanie on usunięty."))
     else:
         messages.warning(request, "Nie udało się dopisać do kolejki.")
     return redirect('course-page', slug=group.course.slug)


### PR DESCRIPTION
Studenci podnoszą, że jest nieintuicyjnym gdy zapisują się do grupy, w której jest miejsce, dostają informację o zapisaniu do kolejki i asynchronicznym procesie, a zaraz potem ich rekord znika (bo przekraczają 35 ECTS).

Nie chciałbym blokować w takich sytuacjach zapisu do kolejki — uważam, że student ma prawo zapisać się do kolejki, licząc, że zapis do grupy nastąpi gdy limit ECTS-ów będzie zwiększony. Natomiast wydaje się, że można w takich sytuacjach studenta ostrzec. 