### PR TITLE
Konfiguracja logów

### DIFF
--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -85,6 +85,15 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'level': 'INFO',
         },
+        'rq_console': {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'timestampthread',
+            'filename': 'logs/rqworker.log',
+            'encoding': 'UTF-8',
+            'maxBytes': 50 * 1024 * 1024,  # 50 MB
+            'backupCount': 5,  # keep this many extra historical files
+        },
     },
     'loggers': {
         'django': {  # configure all of Django's loggers
@@ -93,6 +102,10 @@ LOGGING = {
         },
         'apps': {
             'handlers': ['logfile'],
+            'level': 'DEBUG',
+        },
+        'rq.worker': {
+            'handlers': ['rq_console'],
             'level': 'DEBUG',
         },
     },

--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -74,12 +74,11 @@ LOGGING = {
     },
     'handlers': {
         'logfile': {
-            # optionally raise to INFO to not fill the log file too quickly
-            'level': 'DEBUG',  # DEBUG or higher goes to the log file
+            'level': 'INFO',  # INFO or higher goes to the log file. DEBUG polluted the logs way too much.
             'class': 'logging.handlers.RotatingFileHandler',
             'filename': 'logs/djangoproject.log',
-            'maxBytes': 50 * 10 ** 6,  # will 50 MB do?
-            'backupCount': 3,  # keep this many extra historical files
+            'maxBytes': 50 * 1024 * 1024,  # will 50 MB do?
+            'backupCount': 5,  # keep this many extra historical files
             'formatter': 'timestampthread'
         },
         'console': {

--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -85,7 +85,7 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'level': 'INFO',
         },
-        'rq_console': {
+        'rq_logfile': {
             'level': 'INFO',
             'class': 'logging.handlers.RotatingFileHandler',
             'formatter': 'timestampthread',
@@ -105,7 +105,7 @@ LOGGING = {
             'level': 'DEBUG',
         },
         'rq.worker': {
-            'handlers': ['rq_console'],
+            'handlers': ['rq_logfile'],
             'level': 'DEBUG',
         },
     },


### PR DESCRIPTION
Logi są w tym momencie kompletnie bezużyteczne. Megabajty wypełnione rzygiem z template'ów i pipeline'a. Ta zmiana podwyższa próg, od którego informacje znajdą się w logu, oraz konfiguruje osobny log dla RQ (informacje z workera będą także w domyślnym logu).