### PR TITLE
Zmiany w panelu admina.

### DIFF
--- a/zapisy/apps/enrollment/courses/admin.py
+++ b/zapisy/apps/enrollment/courses/admin.py
@@ -22,8 +22,10 @@ from apps.enrollment.records.signals import GROUP_CHANGE_SIGNAL
 
 
 class GroupInline(admin.TabularInline):
+    fields = ('id', 'teacher', 'get_terms_as_string', 'type', 'limit', 'extra', 'export_usos', 'usos_nr',)
     model = Group
     extra = 0
+    readonly_fields = ('id', 'get_terms_as_string', 'usos_nr',)
     raw_id_fields = ("teacher",)
 
 
@@ -105,7 +107,8 @@ class CourseAdmin(admin.ModelAdmin):
         display those for the currently signed in user.
         """
         qs = super(CourseAdmin, self).get_queryset(request)
-        return qs.select_related('semester')
+        return qs.select_related('semester').prefetch_related('groups', 'groups__term',
+                                                              'groups__term__classrooms')
 
 
 class ClassroomAdmin(admin.ModelAdmin):
@@ -216,7 +219,7 @@ class RecordInline(admin.TabularInline):
 
 
 class GroupAdmin(admin.ModelAdmin):
-    readonly_fields = ('limit', 'id')
+    readonly_fields = ('id',)
     list_display = (
         'id',
         'course',


### PR DESCRIPTION
1. Pozwala zmieniać limit w panelu admina grupy.
![image](https://user-images.githubusercontent.com/5896456/53602023-d6c31180-3bad-11e9-93d4-6a84ef33ab4d.png)

2. Pokazuje id grupy i termy w panelu admina przedmiotu.
![image](https://user-images.githubusercontent.com/5896456/53601941-9c597480-3bad-11e9-82cb-8b008cd65bd1.png)
