### PR TITLE
Przywrócenie eksportu kalendarza

### DIFF
--- a/zapisy/apps/enrollment/timetable/templates/timetable/timetable.html
+++ b/zapisy/apps/enrollment/timetable/templates/timetable/timetable.html
@@ -17,6 +17,8 @@
 
 
 {% block center %}
+    <div style="float:right;margin-bottom: 20px;"><a href="{% url 'ical' %}">{% trans "Eksportuj plan zajęć do pliku .ical" %}</a>
+    </div>
     <div id="timetable"></div>
     <script id="timetable-data" type="application/json">{{ groups_json|safe }}</script>
     {% render_bundle 'timetable-timetable-component' %}

--- a/zapisy/apps/users/views.py
+++ b/zapisy/apps/users/views.py
@@ -378,7 +378,8 @@ def create_ical_file(request: HttpRequest) -> HttpResponse:
     if BaseUser.is_student(user):
         student = user.student
         records = Record.objects.filter(
-            student_id=student.pk, group__course__semester_id=semester.pk
+            student_id=student.pk, group__course__semester_id=semester.pk,
+            status=RecordStatus.ENROLLED
         ).select_related('group', 'group__course', 'group__course__entity')
         groups = [r.group for r in records]
     elif BaseUser.is_employee(user):


### PR DESCRIPTION
Eksport zawierał wszystkie grupy przedmiotów, na które student był
zapisany, zamiast tylko tych, które pojawiają się w planie.

Ze względu na pojawienie się pola statusu w rekordzie zapisania
na przedmiot, należy teraz sprawdzać, czy status zapisania brzmi
faktycznie `ENROLLED`, czy też nie.  Zmiana dotyczy jednego
zapytania do bazy i przywrócenia łącza na stronie planu zajęć.

Closes #643