### PR TITLE
API: Dodaje liczne pola do widoku kursów.

### DIFF
--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 from apps.enrollment.courses.models.classroom import Classroom
 from apps.enrollment.courses.models import CourseEntity, Course, Group, Semester
+from apps.enrollment.courses.models.effects import Effects
 from apps.enrollment.courses.models.term import Term
 from apps.enrollment.records.models import Record
 from apps.offer.desiderata.models import Desiderata, DesiderataOther
@@ -23,37 +24,84 @@ class SemesterSerializer(serializers.ModelSerializer):
         return obj.get_name()
 
 
-class CourseEntitySerializer(serializers.ModelSerializer):
-    """Serializer for CourseEntity
+class EffectsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Effects
+        fields = '__all__'
 
-    When serializing multiple objects, it is important to use
-    `select_related('type')`.
+
+class CourseEntitySerializer(serializers.ModelSerializer):
+    """Serializer for CourseEntity.
+
+    It provides extensible information about CourseEntity object. When
+    serializing multiple objects, it is important to use
+    `select_related('type').prefetch_related('effects',
+    'pointsofcourseentities_set', 'pointsofcourseentities_set__program')`.
     """
     type_short_name = serializers.SerializerMethodField()
+    effects = EffectsSerializer(many=True, read_only=True)
+    points_per_program = serializers.SerializerMethodField()
 
     class Meta:
         model = CourseEntity
-        fields = ('id', 'name', 'type_short_name', 'usos_kod')
-        read_only_fields = ('id', 'name', 'type_short_name')
+        fields = ('id', 'name', 'type_short_name', 'points_per_program', 'effects', 'usos_kod')
+        read_only_fields = ('id', 'name', 'type_short_name', 'effects', 'points_per_program')
 
     def get_type_short_name(self, obj):
         if obj.type is None:
             return None
         return obj.type.short_name
 
+    def get_points_per_program(self, obj):
+        return [{
+            'program': None if p.program is None else p.program.name,
+            'value': p.value
+        } for p in obj.pointsofcourseentities_set.all()]
+
+
+class CourseEntityShallowSerializer(serializers.ModelSerializer):
+    """Shallow serializer for CourseEntity.
+
+    This serializer does not go down into the nested fields. It only exposes
+    basic data like USOS identifier.
+    """
+    class Meta:
+        model = CourseEntity
+        fields = ('id', 'name', 'usos_kod')
+
 
 class CourseSerializer(serializers.ModelSerializer):
     """Serializer for Course.
 
     When serializing multiple objects, it is important to use
-    `select_related('entity', 'entity__type')`.
+    `select_related('entity', 'entity__type',
+    'information').prefetch_related('entity__effects',
+    'entity__pointsofcourseentities_set',
+    'entity__pointsofcourseentities_set__program')`.
     """
     entity = CourseEntitySerializer(read_only=True)
 
     class Meta:
         model = Course
+        fields = ('id', 'entity', 'description', 'semester', 'web_page', 'english', 'lectures',
+                  'repetitions', 'exercises', 'exercises_laboratories', 'laboratories', 'seminars')
+        read_only_fields = ('id', 'entity', 'semester', 'web_page', 'english')
+
+
+class CourseShallowSerializer(serializers.ModelSerializer):
+    """Shallow serializer for the Course model.
+
+    It only exposes the information necessary to identify the course with USOS
+    identifiers — entity and semester.
+
+    Still, in order to make listing courses efficient, query them with
+    `select_related('entity')`
+    """
+    entity = CourseEntityShallowSerializer(read_only=True)
+
+    class Meta:
+        model = Course
         fields = ('id', 'entity', 'semester')
-        read_only_fields = ('id', 'entity', 'semester')
 
 
 class ClassroomSerializer(serializers.ModelSerializer):
@@ -143,7 +191,7 @@ class GroupSerializer(serializers.ModelSerializer):
     When serializing multiple objects, they should be queried with
     `select_related('course', 'course__entity', 'teacher', 'teacher__user')`.
     """
-    course = CourseSerializer(read_only=True)
+    course = CourseShallowSerializer(read_only=True)
     teacher = EmployeeSerializer(read_only=True)
 
     class Meta:

--- a/zapisy/apps/api/rest/v1/views.py
+++ b/zapisy/apps/api/rest/v1/views.py
@@ -29,19 +29,23 @@ class CourseEntityViewSet(viewsets.ModelViewSet):
     """Allows modifying CourseEntity `usos_kod` field."""
     http_method_names = ['patch']
     permission_classes = (IsAdminUser,)
-    queryset = CourseEntity.objects.select_related('type')
+    queryset = CourseEntity.objects.select_related('type').prefetch_related(
+        'effects', 'pointsofcourseentities_set', 'pointsofcourseentities_set__program')
     serializer_class = serializers.CourseEntitySerializer
 
 
 class CourseViewSet(viewsets.ModelViewSet):
     """Lists all courses.
 
-    To only show courses in a given semester, query:
-        /api/v1/?semester={semester_id}
+    To only show courses in a given semester, query
+    `/api/v1/?semester={semester_id}`
     """
     http_method_names = ['get']
     permission_classes = (IsAdminUser,)
-    queryset = Course.objects.select_related('entity', 'entity__type', 'semester')
+    queryset = Course.objects.select_related(
+        'entity', 'entity__type', 'information').prefetch_related(
+            'entity__effects', 'entity__pointsofcourseentities_set',
+            'entity__pointsofcourseentities_set__program')
     filter_fields = ['semester']
     serializer_class = serializers.CourseSerializer
     pagination_class = StandardResultsSetPagination

--- a/zapisy/requirements.common.txt
+++ b/zapisy/requirements.common.txt
@@ -34,3 +34,4 @@ postmarkup==1.2.2
 unidecode==1.0.22
 # PyYAML is used for fixtures.
 pyyaml==3.13
+Markdown==3.0.1


### PR DESCRIPTION
Ten PR poszerza widok kursu o pewne wymienione (i niewymienione) przez @cahirwpz pola.

Obecnie przykładowy kurs (**AiSD M**) wygląda następująco:
![image](https://user-images.githubusercontent.com/5896456/54315144-a59b0600-45dd-11e9-81b4-ce8733936a9d.png)

Proszę zwrócić uwagę na listę `points_per_program` — dla niektórych programów studiów będą tam wartości ECTS. Wpis, w którym program studiów to _null_ definiuje domyślą wartość przedmiotu.

@cahirwpz Przyjrzyj się, czy jeszcze jakichś danych brakuje Ci w tym widoku i przemów teraz, albo zamilknij na wieki!