### PR TITLE
Dodaje plik z konfiguracją Vagrantfila

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ zapisy/webpack_resources/webpack-stats.json
 *.gz
 *.sql
 *.sqlite3
+vagrant.yml

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
+
+begin
+  settings = YAML.load_file 'vagrant.yml'
+rescue Errno::ENOENT
+  settings = {}
+end
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
@@ -25,7 +32,11 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb|
     # Customize the amount of memory on the VM:
-    vb.memory = "1024"
+    if settings['mem']
+      vb.memory = settings['mem']
+    else
+      vb.memory = "1024"
+    end
     # The folder "node_modules" will live somewhere else and only be mounted
     # in /vagrant/zapisy to avoid the issue with symlinks on Windows.
     config.vm.provision "shell", inline: <<-SHELL


### PR DESCRIPTION
PR dodaje możliwość czytania konfiguracji maszyny wirtualnej z zewnętrznego pliku o nazwie `vagrant.yml`, nie będącego częścią repo. Jest to zwykły plik w formacie yaml, wystarczy sworzyć go w głownym katalogu, i umieścić w nim:
```
mem: 2048
```
Oczywiście ilość RAMu trzeba dobrać do swoich potrzeb, gdy jest go za mało to pojawiają się błędy przy kompilacji javascriptu, zazwyczaj około 1600 wystarcza.
W przypadku braku takiego pliku, używana jest domyślna ilość ramu, czyli 1024 MB.