### PR TITLE
Aktualizacja niektórych paczek, w tym Django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
         key_url: 'http://dl.yarnpkg.com/debian/pubkey.gpg'
     packages:
       - yarn
+  postgresql: '9.6'
 services:
   - postgresql
 

--- a/zapisy/apps/users/urls.py
+++ b/zapisy/apps/users/urls.py
@@ -1,7 +1,6 @@
 from typing import List, Union, Any
 from django.conf.urls import url
-from django.contrib.auth.views import password_reset, password_reset_confirm, \
-    password_reset_complete, password_reset_done, PasswordChangeView
+
 from . import views
 
 urlpatterns = [
@@ -12,13 +11,6 @@ urlpatterns = [
     url('^email-change/$', views.email_change, name='email-change'),
     url('^setlang/$', views.set_language, name='setlang'),
     url('^employee-data-change/$', views.consultations_change, name='consultations-change'),
-    url('^password-change/$', PasswordChangeView.as_view(template_name='users/password_change_form.html'),
-        name='password_change'),
-    url('^password-change-done/$', views.password_change_done, name='password_change_done'),
-    url('^password-reset/$', password_reset, {'template_name': 'users/password_reset_form.html'}, name='password_reset'),
-    url('^password-reset-done/$', password_reset_done, {'template_name': 'users/password_reset_done.html'}, name='password_reset_done'),
-    url(r'^password-reset-confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>.+)/$', password_reset_confirm, {'template_name': 'users/password_reset_confirm.html'}, name='password_reset_confirm'),
-    url('^password-reset-complete/$', password_reset_complete, {'template_name': 'users/password_reset_complete.html'}, name='password_reset_complete'),
     url('^logout/$', views.cas_logout, name='user-logout'),
     url('^employees/$', views.employees_list, name='employees-list'),
     url('^students/$', views.students_list, name='students-list'),

--- a/zapisy/apps/users/views.py
+++ b/zapisy/apps/users/views.py
@@ -209,14 +209,6 @@ def consultations_change(request: HttpRequest) -> HttpResponse:
 
 
 @login_required
-def password_change_done(request: HttpRequest) -> HttpResponse:
-    """informs if password were changed"""
-    logger.info('User (%s) changed password' % request.user.get_full_name())
-    messages.success(request, "Twoje hasło zostało zmienione.")
-    return HttpResponseRedirect(reverse('my-profile'))
-
-
-@login_required
 def my_profile(request):
     """User profile page.
 
@@ -337,7 +329,7 @@ def cas_logout(request, **kwargs) -> HttpResponse:
     using the legacy protocol (version 2), rewrite the given url to match
     the new schema. If not, simply return the original response.
     """
-    response = cas_baseviews.logout(request, **kwargs)
+    response = cas_baseviews.LogoutView.as_view()(request, **kwargs)
 
     if (isinstance(response, HttpResponseRedirect) and
             int(settings.CAS_VERSION) == 2):

--- a/zapisy/requirements.common.txt
+++ b/zapisy/requirements.common.txt
@@ -19,7 +19,6 @@ djangorestframework==3.8.2
 Fabric3==1.14.post1
 ipdb==0.11
 ipython==6.4.0
-psycopg2==2.7.4
 pycryptodome==3.8.1
 rollbar==0.13.17
 newrelic==2.68.0.50

--- a/zapisy/requirements.common.txt
+++ b/zapisy/requirements.common.txt
@@ -1,11 +1,11 @@
-Django==2.0.8
+Django~=2.1.0
 django-bootstrap-pagination==1.7.0
-django-cas-ng==3.5.9
+django-cas-ng==3.6.0
 django-crispy-forms==1.7.2
 choicesenum==0.4
 django-environ==0.4.4
 django-extensions==2.0.7
-django-filter==1.1.0
+django-filter==2.1.0
 django-mailer==1.0.0
 django-modeltranslation==0.13b1
 django-pipeline==1.3.16
@@ -20,7 +20,7 @@ Fabric3==1.14.post1
 ipdb==0.11
 ipython==6.4.0
 psycopg2==2.7.4
-pycryptodome==3.6.1
+pycryptodome==3.8.1
 rollbar==0.13.17
 newrelic==2.68.0.50
 gunicorn==19.7.1
@@ -34,4 +34,4 @@ postmarkup==1.2.2
 # Remove accents from strings (diacritics converted to Latin equivalents)
 unidecode==1.0.22
 # PyYAML is used for fixtures.
-pyyaml==3.13
+pyyaml==5.1

--- a/zapisy/requirements.production.txt
+++ b/zapisy/requirements.production.txt
@@ -1,1 +1,3 @@
 -r requirements.common.txt
+
+psycopg2==2.8

--- a/zapisy/requirements.test.txt
+++ b/zapisy/requirements.test.txt
@@ -1,5 +1,8 @@
 -r requirements.common.txt
 
+# Reduce testing time by using binary psycopg2 package.
+psycopg2-binary==2.8
+
 factory_boy==2.11.1
 coverage==4.5.1
 flake8==3.5.0

--- a/zapisy/requirements.test.txt
+++ b/zapisy/requirements.test.txt
@@ -3,5 +3,4 @@
 factory_boy==2.11.1
 coverage==4.5.1
 flake8==3.5.0
-PyYAML==3.13
 parameterized==0.6.1

--- a/zapisy/templates/base.html
+++ b/zapisy/templates/base.html
@@ -1,7 +1,7 @@
 {# Base template for an entire System #}
 
 {% load fereol_common %}
-{% load staticfiles %}
+{% load static %}
 {% load should_display_debug %}
 {% load debug_info %}
 {% load i18n %}
@@ -141,6 +141,7 @@
                                         <div class="form-group">
                                             <label>Login</label>
                                             <input type="text" class="form-control"
+                                                    name="username"
                                                     placeholder="Użytkownik"
                                                     oninvalid="this.setCustomValidity('Nazwa użytkownika jest wymagana')"
                                                     required>

--- a/zapisy/templates/consent-dialog.html
+++ b/zapisy/templates/consent-dialog.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load render_bundle from webpack_loader %}
 <div class="modal fade" id="consentDialog" tabindex="-1" role="dialog" aria-hidden="false">
     <div class="modal-dialog modal-dialog-centered" role="document">

--- a/zapisy/templates/grade/poll/poll_results.html
+++ b/zapisy/templates/grade/poll/poll_results.html
@@ -1,5 +1,5 @@
 ﻿{% extends "grade/base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load compressed %}
 
 {% block  main-subtitle %}Wyniki Oceny{% endblock %}

--- a/zapisy/templates/offer/desiderata/change_desiderata.html
+++ b/zapisy/templates/offer/desiderata/change_desiderata.html
@@ -1,5 +1,5 @@
 {% extends "offer/base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block main-subtitle %}Dezyderaty{% endblock %}
 {% block js %}

--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -183,7 +183,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'middleware.error_handling.ErrorHandlerMiddleware',
-    'pipeline.middleware.MinifyHTMLMiddleware',
     'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',
 ]
 

--- a/zapisy/zapisy/urls.py
+++ b/zapisy/zapisy/urls.py
@@ -24,7 +24,6 @@ urlpatterns = [
 
     url(r'^news/', include('apps.news.urls')),
     url(r'^users/', include('apps.users.urls')),
-    url('accounts/', include('apps.email_change.urls')),
 
     url(r'^grade/', include('apps.grade.urls')),
     url(r'^feeds/news/$', LatestNews()),
@@ -42,9 +41,13 @@ urlpatterns = [
     url(r'^vote/', include('apps.offer.vote.urls')),
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     url(r'^fereol_admin/', admin.site.urls),
-    url(r'^accounts/login$', cas_views.login, name='cas_ng_login'),
-    url(r'^accounts/logout$', users_views.cas_logout, name='cas_ng_logout'),
-    url(r'^accounts/callback$', cas_views.callback, name='cas_ng_proxy_callback'),
+
+
+    path('accounts/', include('apps.email_change.urls')),
+    path('accounts/', include('django.contrib.auth.urls')),
+    path('accounts/login', cas_views.LoginView.as_view(), name='cas_ng_login'),
+    path('accounts/logout', users_views.cas_logout, name='cas_ng_logout'),
+    path('accounts/callback', cas_views.CallbackView.as_view(), name='cas_ng_proxy_callback'),
 ]
 
 urlpatterns += [


### PR DESCRIPTION
Aktualizujemy niektóre zależności, których używaliśmy w wersjach już nie wspieranych.
  1. __Django__ z wersji _2.0.8_ do _2.1.*_.
  2. __pycryptodome__ z wersji _3.6.1_ do _3.8.1_.
  3. __psycopg2__ (które rzucało warningami) z wersji _2.7.4_ do _2.8_. Od tej wersji paczka dostarczana jest na dwa sposoby. My będziemy używać na produkcji wersji kompilowanej ze źródeł, a lokalnie i do testowania wersji binarnej.
  4. __pyYAML__ z wersji _3.13_ do _5.1_.
  5. __django-cas-ng__ z wersji _3.5.9_ do _3.6.0_.
  6. __django-filter__ z wersji _1.1_ do _2.1_.

Przy okazji aktualizacji Django trzeba było dokonać pewnych drobnych korekt:
  - Z Django 2.1 zniknęły funkcje–widoki związane z autoryzacją i zostały zastąpione przez klasy-widoki. Postanowiłem zmienić sposób używania tych widoków — zamiast listować każdy z nich w pliku `urls.py` po prostu odwołujemy się do _url-i_ zdefiniowanych przez Django. Widoczny efekt tej zmiany jest taki, że użytkownik przy resetowaniu hasła będzie widział template Django-wy, a nie nasz (p. https://docs.djangoproject.com/en/2.2/releases/2.1/#features-removed-in-2-1, kropka pierwsza).
  - Po aktualizacji zwracane przez Django odpowiedzi strasznie się skaszaniły — zamiast HTML-a zwracany był pythonowy byte-string (poprzedzony nawet ```b'```). Odpowiedzialny za to był _Middleware_ minifikujący zwracanego HTML-a, który jest częścią _Pipeline'a_ (a tego chcemy się pozbyć). Jako że i tak używamy Ngnix'a, który kompresuje odpowiedzi serwera, nie wierzę w korzyść z tego _middleware_, więc go usunąłem.
  - Django 2.1 wymaga Postgresql'a w wersji 9.4 lub wyższej. Na Travisie domyślnie była 9.2, podbijamy ją do 9.6 używanej na produkcji. 