### PR TITLE
Usuwa niektóre pola z panelu admina grupy.

### DIFF
--- a/zapisy/apps/enrollment/courses/admin.py
+++ b/zapisy/apps/enrollment/courses/admin.py
@@ -204,9 +204,9 @@ class TermInline(admin.TabularInline):
 class RecordInline(admin.TabularInline):
     model = Record
     extra = 0
-    readonly_fields = ('id',)
+    fields = ('student', 'status',)
     raw_id_fields = ('student',)
-    can_delete = True
+    can_delete = False
 
     def get_queryset(self, request):
         """Only shows enrolled and queued students.


### PR DESCRIPTION
W panelu admina nie dało się zmodyfikować grupy wykładowej z AiSD (191 zapisanych studentów) ponieważ liczba pól w formularzu przekraczała 1000 (https://docs.djangoproject.com/en/2.2/ref/settings/#data-upload-max-number-fields). Z tymi zmianami pól jest ciut ponad 800.