### PR TITLE
Teacher can be null

### DIFF
--- a/zapisy/apps/notifications/signals.py
+++ b/zapisy/apps/notifications/signals.py
@@ -38,7 +38,7 @@ def notify_that_student_was_pulled_from_queue(sender: Record, **kwargs) -> None:
         Notification(
             get_id(), get_time(), NotificationType.PULLED_FROM_QUEUE, {
                 'course_name': group.course.information.entity.name,
-                'teacher': group.teacher.user.get_full_name(),
+                'teacher': group.get_teacher_full_name(),
                 'type': group.get_type_display(),
             }, target))
 
@@ -56,7 +56,7 @@ def notify_that_student_was_not_pulled_from_queue(sender: Record, **kwargs) -> N
         Notification(
             get_id(), get_time(), NotificationType.NOT_PULLED_FROM_QUEUE, {
                 'course_name': group.course.information.entity.name,
-                'teacher': group.teacher.user.get_full_name(),
+                'teacher': group.get_teacher_full_name(),
                 'type': group.get_type_display(),
                 'reason': kwargs['reason']
             }, target))
@@ -69,14 +69,15 @@ def notify_that_group_was_added_in_course(sender: Group, **kwargs) -> None:
         course_groups = Group.objects.filter(course=group.course)
         course_name = group.course.information.entity.name
 
-        teacher = group.teacher.user
-        target = reverse(course_view, args=[group.course.slug])
+        if group.teacher is not None:
+            teacher = group.teacher.user
+            target = reverse(course_view, args=[group.course.slug])
 
-        notify_user(
-            teacher,
-            Notification(get_id(), get_time(),
-                         NotificationType.ASSIGNED_TO_NEW_GROUP_AS_A_TEACHER,
-                         {'course_name': course_name}, target))
+            notify_user(
+                teacher,
+                Notification(get_id(), get_time(),
+                            NotificationType.ASSIGNED_TO_NEW_GROUP_AS_A_TEACHER,
+                            {'course_name': course_name}, target))
 
         records = Record.objects.filter(group__in=course_groups,
                                         status=RecordStatus.ENROLLED).select_related('student',
@@ -88,7 +89,7 @@ def notify_that_group_was_added_in_course(sender: Group, **kwargs) -> None:
                 get_id(), get_time(),
                 NotificationType.ADDED_NEW_GROUP, {
                     'course_name': course_name,
-                    'teacher': teacher.get_full_name()
+                    'teacher': group.get_teacher_full_name()
                 }, target))
 
 
@@ -96,15 +97,16 @@ def notify_that_group_was_added_in_course(sender: Group, **kwargs) -> None:
 def notify_that_teacher_was_changed(sender: Group, **kwargs) -> None:
     group = kwargs['instance']
 
-    teacher = group.teacher.user
-    course_name = group.course.information.entity.name
-    target = reverse(course_view, args=[group.course.slug])
+    if group.teacher is not None:
+        teacher = group.teacher.user
+        course_name = group.course.information.entity.name
+        target = reverse(course_view, args=[group.course.slug])
 
-    notify_user(
-        teacher,
-        Notification(get_id(), get_time(),
-                     NotificationType.ASSIGNED_TO_NEW_GROUP_AS_A_TEACHER,
-                     {'course_name': course_name}, target))
+        notify_user(
+            teacher,
+            Notification(get_id(), get_time(),
+                        NotificationType.ASSIGNED_TO_NEW_GROUP_AS_A_TEACHER,
+                        {'course_name': course_name}, target))
 
     queued_users = User.objects.filter(
         student__record__group=group,
@@ -120,7 +122,7 @@ def notify_that_teacher_was_changed(sender: Group, **kwargs) -> None:
             get_id(), get_time(),
             NotificationType.TEACHER_HAS_BEEN_CHANGED_QUEUED, {
                 'course_name': course_name,
-                'teacher': teacher.get_full_name(),
+                'teacher': group.get_teacher_full_name(),
                 'type': group.get_type_display(),
             }, target))
 

--- a/zapisy/apps/notifications/signals.py
+++ b/zapisy/apps/notifications/signals.py
@@ -76,21 +76,19 @@ def notify_that_group_was_added_in_course(sender: Group, **kwargs) -> None:
             notify_user(
                 teacher,
                 Notification(get_id(), get_time(),
-                            NotificationType.ASSIGNED_TO_NEW_GROUP_AS_A_TEACHER,
-                            {'course_name': course_name}, target))
+                             NotificationType.ASSIGNED_TO_NEW_GROUP_AS_A_TEACHER,
+                             {'course_name': course_name}, target))
 
-        records = Record.objects.filter(group__in=course_groups,
-                                        status=RecordStatus.ENROLLED).select_related('student',
-                                                                                     'student__user')
+        records = Record.objects.filter(
+            group__in=course_groups, status=RecordStatus.ENROLLED).select_related(
+                'student', 'student__user')
         users = {element.student.user for element in records}
         notify_selected_users(
             users,
-            Notification(
-                get_id(), get_time(),
-                NotificationType.ADDED_NEW_GROUP, {
-                    'course_name': course_name,
-                    'teacher': group.get_teacher_full_name()
-                }, target))
+            Notification(get_id(), get_time(), NotificationType.ADDED_NEW_GROUP, {
+                'course_name': course_name,
+                'teacher': group.get_teacher_full_name()
+            }, target))
 
 
 @receiver(teacher_changed, sender=Group)
@@ -104,23 +102,19 @@ def notify_that_teacher_was_changed(sender: Group, **kwargs) -> None:
 
         notify_user(
             teacher,
-            Notification(get_id(), get_time(),
-                        NotificationType.ASSIGNED_TO_NEW_GROUP_AS_A_TEACHER,
-                        {'course_name': course_name}, target))
+            Notification(get_id(), get_time(), NotificationType.ASSIGNED_TO_NEW_GROUP_AS_A_TEACHER,
+                         {'course_name': course_name}, target))
 
     queued_users = User.objects.filter(
-        student__record__group=group,
-        student__record__status=RecordStatus.QUEUED)
+        student__record__group=group, student__record__status=RecordStatus.QUEUED)
 
     enrolled_users = User.objects.filter(
-        student__record__group=group,
-        student__record__status=RecordStatus.ENROLLED)
+        student__record__group=group, student__record__status=RecordStatus.ENROLLED)
 
     notify_selected_users(
         queued_users,
         Notification(
-            get_id(), get_time(),
-            NotificationType.TEACHER_HAS_BEEN_CHANGED_QUEUED, {
+            get_id(), get_time(), NotificationType.TEACHER_HAS_BEEN_CHANGED_QUEUED, {
                 'course_name': course_name,
                 'teacher': group.get_teacher_full_name(),
                 'type': group.get_type_display(),
@@ -129,8 +123,7 @@ def notify_that_teacher_was_changed(sender: Group, **kwargs) -> None:
     notify_selected_users(
         enrolled_users,
         Notification(
-            get_id(), get_time(),
-            NotificationType.TEACHER_HAS_BEEN_CHANGED_ENROLLED, {
+            get_id(), get_time(), NotificationType.TEACHER_HAS_BEEN_CHANGED_ENROLLED, {
                 'course_name': course_name,
                 'teacher': teacher.get_full_name(),
                 'type': group.get_type_display(),
@@ -146,6 +139,4 @@ def notify_that_news_was_added(sender: News, **kwargs) -> None:
     target = reverse(all_news)
 
     notify_selected_users(
-        users,
-        Notification(get_id(), get_time(),
-                     NotificationType.NEWS_HAS_BEEN_ADDED, {}, target))
+        users, Notification(get_id(), get_time(), NotificationType.NEWS_HAS_BEEN_ADDED, {}, target))


### PR DESCRIPTION
W definicji modelu grupy, pole `teacher` może być puste. Funkcje w nowej aplikacji _Notifications_ nie brały tego jednak pod uwagę i wysypywały się przy grupie z pustym polem `teacher`.