### PR TITLE
Sets proposal form id.

### DIFF
--- a/zapisy/apps/offer/proposal/assets/markdown-editor.js
+++ b/zapisy/apps/offer/proposal/assets/markdown-editor.js
@@ -2,7 +2,7 @@ import Vue from "vue/dist/vue.js";
 import MarkdownEditor from "./MarkdownEditor.vue";
 
 new Vue({
-    el: "form",
+    el: "#edit-proposal-form",
     components: {
         "markdown-editor": MarkdownEditor,
     },

--- a/zapisy/apps/offer/proposal/forms.py
+++ b/zapisy/apps/offer/proposal/forms.py
@@ -298,6 +298,7 @@ class ProposalFormHelper(helper.FormHelper):
 
     Fields here must be the same as in `EditProposalForm`.
     """
+    form_id = 'edit-proposal-form'
     layout = layout.Layout(
         layout.Fieldset(
             "Informacje podstawowe",


### PR DESCRIPTION
The form had previously no HTML id. The id has however become necessary
when another form appeared on a site, because the markdown-editor had ceased to
work.