### PR TITLE
Poprawna obsługa błędów instalacji paczek lub kompilacji Webpack'iem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ install:
   - |
     if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then
       # Installs Yarn/NPM dependencies.
-      cd zapisy && yarn && cd ..
+      (cd zapisy && yarn) || exit 1
       # Builds assets.
-      cd zapisy && yarn build && cd ..
+      (cd zapisy && yarn build) || exit 1
       # Don't store the build cache; it changes after each build, Travis then
       # picks that change up and repacks the cache archive which takes forever
       rm -rf zapisy/node_modules/.cache-loader-*


### PR DESCRIPTION
PR wprowadza poprawki do `.travis.yml`, tak, by przy błędach instalacji paczek npm bądź kompilacji frontendu błąd na Travisie był zrozumiały dla autora commitu; w tej chwili takie buildy zatrzymywane są z następującą, dość zagadkową informacją ([przykład](https://travis-ci.org/iiuni/projektzapisy/jobs/573357520)):

> mv: cannot stat 'env/.env_travis': No such file or directory
> The command "mv env/.env_travis env/.env" failed and exited with 1 during .
> Your build has been stopped.

**Wyjaśnienie**

Skrypt zdefiniowany w linijce 20 w pliku `.travis.yml` instaluje paczki npm, następnie uruchamia kompilację Webpack'iem. Ponieważ katalogiem roboczym jest główny katalog projektu, a powyższe kroki trzeba wykonywać z katalogu `zapisy/`, oba z nich napisane są wg szablonu `cd zapisy && ... && cd ..`. Jeżeli jednak komenda wpisana w miejsce kropek (...) nie powiedzie się, i zwróci niezerowy kod wyjścia, polecenie `cd ..` nie zostanie wykonane, a Bash po cichu przejdzie dalej, i wykonanie całej instrukcji warunkowej zakończy się powodzeniem z punktu widzenia Travisa. Nie powiedzie się natomiast komenda przygotowująca plik `.env`, który zawiera informacje m.in. o koncie bazy danych itd, ponieważ nie znajdujemy się już w głównym katalogu projektu z powodu nie wykonania polecenia `cd ..`. Skutkuje to przywołanym powyżej komunikatem błędu.

Chcielibyśmy, aby błędy instalacji paczek i kompilacji natychmiast przerywały build ze statusem _failed_, nie _errored_ (_errored_ - wewnętrzny problem przy wykonywaniu skryptu); wychodzimy bowiem z założenia, że błąd kompilacji czy instalacji paczek to wina danego committa, jego autor powinien więc być o tym poinformowany, by naprawić problem.

W tym PR zmieniamy dwa problematyczne wywołania na _sub-shell_; zmiana aktualnego katalogu w pod-powłoce nie wpływa na katalog roboczy rodzica, a kod wyjścia z pod-powłoki mówi nam, czy powiodło się zawarte w niej polecenie. Dzięki temu, w przypadku niepowodzenia, możemy od razu zareagować poprzez wywołanie `exit 1`, co daje nam pożądane zachowanie.