### PR TITLE
Resetowanie statusu przy klonowaniu propozycji.

### DIFF
--- a/zapisy/apps/offer/proposal/models.py
+++ b/zapisy/apps/offer/proposal/models.py
@@ -145,6 +145,9 @@ class Proposal(CourseInformation):
         copy.level = None
         copy.year = None
 
+        # Resets the status back to default.
+        copy.status = ProposalStatus.DRAFT
+
         copy.name = "Klon: " + copy.name
         if copy.name_en:
             copy.name_en = "Clone: " + copy.name_en


### PR DESCRIPTION
Naprawia niedawno zrelacjonowany mi błąd pojawiający się przy klonowaniu
propozycji: skopiowaniu do formularza ulega również status, a próba
zapisu formularza skutkuje pojawieniem się błędu, bo nie można zapisać
nowej propozycji ze statusem innym niż DRAFT. Dopiero po wyświetleniu
tego komunikatu status się resetuje.

Naprawiamy ten błąd poprzez wprowadzenie poprawki do metody `__copy__`.