### PR TITLE
Drobne zmiany w aplikacji Notifications

### DIFF
--- a/zapisy/apps/news/urls.py
+++ b/zapisy/apps/news/urls.py
@@ -3,5 +3,5 @@ from . import views
 
 urlpatterns = [
     url(r'^$', views.all_news, name='news-all'),
-    url(r'^(?P<news_id>[0-9]+)/$', views.all_news_focus_one),
+    url(r'^(?P<news_id>[0-9]+)/$', views.all_news_focus_one, name='news-one'),
 ]

--- a/zapisy/apps/notifications/api.py
+++ b/zapisy/apps/notifications/api.py
@@ -8,14 +8,17 @@ from apps.notifications.repositories import get_notifications_repository
 from apps.notifications.tasks import dispatch_notifications_task
 
 
-def notify_user(user: User, notification: Notification):
+def notify_user(user: User, notification: Notification, repo=None):
     """Dispatch one notification to one user.
 
     Repository saves notification to redis.
     Then we queue user to send (regarding preferences)
     all his pending notifications, including this one.
+
+    Notifications repository can be initialised outside for perfomance reasons.
     """
-    repo = get_notifications_repository()
+    if repo is None:
+        repo = get_notifications_repository()
     repo.save(user, notification)
     if not settings.RUN_ASYNC:
         dispatch_notifications_task(user)
@@ -25,5 +28,6 @@ def notify_user(user: User, notification: Notification):
 
 def notify_selected_users(users: List[User], notification: Notification):
     """Dispatch one notification to multiple users."""
+    repo = get_notifications_repository()
     for user in users:
-        notify_user(user, notification)
+        notify_user(user, notification, repo)

--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -103,14 +103,15 @@ export default class NotificationsComponent extends Vue{
                 <div v-for="elem in n_list" :key="elem.key" class="toast mb-1 show">
                     <div class="toast-header">
                         <strong class="mr-auto"></strong>
-                        <small class="text-muted">{{ elem.issued_on|Moment }}</small>
+                        <small class="text-muted mx-2">{{ elem.issued_on|Moment }}</small>
                         <button type="button" class="close" @click="deleteOne(elem.key)">
                             &times;
                         </button>
                     </div>
-                    <div class="toast-body">
-                        <a :href="elem.target" class="text-body" v-html="elem.description"></a>
-                    </div>
+                    <a :href="elem.target" class="toast-link">
+                        <div class="toast-body text-body"
+                        v-html="elem.description"></div>
+                    </a>
                 </div>
             </form>
             <form>
@@ -142,6 +143,13 @@ export default class NotificationsComponent extends Vue{
     for tag <a> in .dropdown-menu  */
 .specialdropdown::after{
     content: none;
+}
+
+a.toast-link:hover {
+    text-decoration: none;
+    .toast-body {
+        background-color: var(--light);
+    }
 }
 
 .place-for-notifications{

--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -109,6 +109,7 @@ export default class NotificationsComponent extends Vue{
             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <div v-if="n_counter" @click="getNotifications()">
                 <i class="fas fa-bell fa-lg"></i>
+                <span class="counter-badge">{{ n_counter }}</span>
             </div>
             <div v-else>
                <i class="far fa-bell fa-lg"></i>
@@ -143,8 +144,7 @@ export default class NotificationsComponent extends Vue{
 </div>
 </template>
 
-<style>
-
+<style lang="scss" scoped>
 /*  Modification of the bootstrap class .dropdown-menu
     for display notifications widget correctly.  */
 #notification-dropdown .dropdown-menu{
@@ -162,6 +162,25 @@ export default class NotificationsComponent extends Vue{
 .place-for-notifications{
     max-height: 395px;
     overflow-y: auto;
+}
+
+.counter-badge {
+    background-color: var(--pink);
+    border-radius: 2px;
+    color: white;
+    font-weight: bold;
+    
+    padding: 1px 3px;
+
+    // Bootstrap breakpoint at which the navbar is fully expanded.
+    @media (min-width: 992px) {
+        font-size: 10px;
+
+        position: absolute; /* Position the badge within the relatively positioned button */
+        top: 2px;
+        right: 2px;
+    }
+    margin-left: .25em;
 }
 
 </style>

--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -4,7 +4,7 @@ import Component from "vue-class-component";
 import axios, { AxiosProxyConfig, AxiosPromise } from 'axios';
 import moment from 'moment'
 
-interface NotificationsArray {
+interface Notifications {
     id: string;
     description: string;
     issued_on: string;
@@ -12,7 +12,7 @@ interface NotificationsArray {
 }
 
 interface NotificationsDict {
-    [key: string]: NotificationsArray;
+    [key: string]: Notifications;
 }
 
 interface ServerResponseDict {
@@ -91,20 +91,20 @@ export default class NotificationsComponent extends Vue{
         <a class="nav-link dropdown-toggle specialdropdown ml-1" href="#" id="navbarDropdown" role="button"
             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <div v-if="n_counter !== 0">
-                <i class="fas fa-bell fa-lg"></i>
+                <font-awesome-icon :icon="['fas', 'bell']" size="lg" />
                 <span class="counter-badge">{{ n_counter }}</span>
             </div>
             <div v-else>
-               <i class="far fa-bell fa-lg"></i>
+               <font-awesome-icon :icon="['far', 'bell']" size="lg" />
             </div>
         </a>
-        <div class="dropdown-menu dropdown-menu-right m-2 pb-2 pt-0">
-            <form class="p-2 place-for-notifications">
-                <div v-for="elem in n_list" :key="elem.key" class="toast fade show mw-100 mb-2">
+        <div class="dropdown-menu dropdown-menu-right">
+            <form class="p-1 place-for-notifications">
+                <div v-for="elem in n_list" :key="elem.key" class="toast mb-1 show">
                     <div class="toast-header">
                         <strong class="mr-auto"></strong>
                         <small class="text-muted">{{ elem.issued_on|Moment }}</small>
-                        <button type="button" class="ml-2 mb-1 close" @click="deleteOne(elem.key)">
+                        <button type="button" class="close" @click="deleteOne(elem.key)">
                             &times;
                         </button>
                     </div>
@@ -131,7 +131,9 @@ export default class NotificationsComponent extends Vue{
 /*  Modification of the bootstrap class .dropdown-menu
     for display notifications widget correctly.  */
 #notification-dropdown .dropdown-menu{
-    min-width: 350px;
+    @media (min-width: 992px) {
+        min-width: 350px;
+    }
     max-height: 500px;
     right: -160px;
 }

--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -109,7 +109,7 @@ export default class NotificationsComponent extends Vue{
                         </button>
                     </div>
                     <div class="toast-body">
-                        <a :href="elem.target" class="text-body">{{ elem.description }}</a>
+                        <a :href="elem.target" class="text-body" v-html="elem.description"></a>
                     </div>
                 </div>
             </form>

--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -33,18 +33,10 @@ interface ServerResponseCount {
 })
 export default class NotificationsComponent extends Vue{
 
-    n_counter: number|null = null;
     n_list: NotificationsDict = {};
 
-    getCount(): Promise<number> {
-        return axios.get('/notifications/count')
-        .then((result: ServerResponseCount) => {
-            return result.data
-        })
-    }
-
-    async updateCounter(): Promise<void>{
-        this.n_counter = await this.getCount();
+    get n_counter(): number {
+        return Object.keys(this.n_list).length;
     }
 
     getNotifications(): Promise<void> {
@@ -60,8 +52,7 @@ export default class NotificationsComponent extends Vue{
 
         return axios.post('/notifications/delete/all')
         .then((request: ServerResponseDict) => {
-            this.n_list = request.data
-            this.updateCounter();
+            this.n_list = request.data;
         })
     }
 
@@ -81,21 +72,13 @@ export default class NotificationsComponent extends Vue{
                 'Content-Type': 'multipart/form-data',
             }
         }).then((request: ServerResponseDict) => {
-            this.n_list = request.data
-            this.updateCounter();
+            this.n_list = request.data;
         })
     }
 
-    refresh(): void{
-        if(this.n_counter){}
-        else{
-            this.updateCounter();
-        }
-    }
-
     async created() {
-        await this.updateCounter()
-        setInterval(this.refresh, 2000);
+        this.getNotifications();
+        setInterval(this.getNotifications, 30000);
     }
 
 }
@@ -107,7 +90,7 @@ export default class NotificationsComponent extends Vue{
     <li id="notification-dropdown" class="nav-item dropdown">
         <a class="nav-link dropdown-toggle specialdropdown ml-1" href="#" id="navbarDropdown" role="button"
             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <div v-if="n_counter" @click="getNotifications()">
+            <div v-if="n_counter !== 0">
                 <i class="fas fa-bell fa-lg"></i>
                 <span class="counter-badge">{{ n_counter }}</span>
             </div>

--- a/zapisy/apps/notifications/assets/notifications-widget.js
+++ b/zapisy/apps/notifications/assets/notifications-widget.js
@@ -1,12 +1,21 @@
 import Vue from "vue";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faBell as fasBell } from "@fortawesome/free-solid-svg-icons/faBell";
+import { faBell as farBell } from "@fortawesome/free-regular-svg-icons/faBell";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+
 import Widget from "./components/Widget.vue";
+
+library.add(fasBell, farBell);
+
+Vue.component("font-awesome-icon", FontAwesomeIcon);
 
 let notifications_app = new Vue({
     el: "#notificationswidget",
-    components: { 
-        Widget 
+    components: {
+        Widget
     },
-    render: function (h) {
+    render: function(h) {
         return h(Widget);
-    },
-}) 
+    }
+});

--- a/zapisy/apps/notifications/signals.py
+++ b/zapisy/apps/notifications/signals.py
@@ -11,7 +11,6 @@ from apps.enrollment.courses.models.group import Group
 from apps.enrollment.courses.views import course_view
 from apps.enrollment.records.models import Record, RecordStatus
 from apps.news.models import News
-from apps.news.views import all_news
 from apps.notifications.api import notify_user, notify_selected_users
 from apps.notifications.custom_signals import teacher_changed, student_pulled, student_not_pulled
 from apps.notifications.templates import NotificationType
@@ -134,9 +133,18 @@ def notify_that_teacher_was_changed(sender: Group, **kwargs) -> None:
 def notify_that_news_was_added(sender: News, **kwargs) -> None:
     news = kwargs['instance']
 
-    records = list(Employee.get_actives()) + list(Student.objects.filter(status=0))
-    users = {element.user for element in records}
-    target = reverse(all_news)
+    # Do not notify about hidden news.
+    if news.category == '-':
+        return
+
+    records = list(Employee.get_actives().select_related('user')) + list(
+        Student.objects.filter(status=0).select_related('user'))
+    users = [element.user for element in records]
+    target = reverse('news-one', args=[news.id])
 
     notify_selected_users(
-        users, Notification(get_id(), get_time(), NotificationType.NEWS_HAS_BEEN_ADDED, {}, target))
+        users,
+        Notification(get_id(), get_time(), NotificationType.NEWS_HAS_BEEN_ADDED, {
+            'title': news.title,
+            'contents': news.body
+        }, target))

--- a/zapisy/apps/notifications/templates.py
+++ b/zapisy/apps/notifications/templates.py
@@ -29,5 +29,6 @@ mapping = {
     'Nastąpiła zmiana prowadzacego w grupie przedmiotu "{course_name}", do której jesteś w kolejce. '
     'Typ grupy to {type}, a nowy prowadzący to {teacher}.',
     NotificationType.NEWS_HAS_BEEN_ADDED:
-    'Dodano nową wiadomość w aktualnościach.',
+    "Dodano nową wiadomość w aktualnościach: {title}\n"
+    "{contents}",
 }

--- a/zapisy/apps/notifications/templates/notifications/email_base.html
+++ b/zapisy/apps/notifications/templates/notifications/email_base.html
@@ -3,7 +3,7 @@
     <body>
         {{ greeting }},<br>
         <br>
-        {{ content }}
+        {{ content|safe }}
         <br><br>
         Zespół zapisy.ii.uni.wroc.pl<br>
         <br>

--- a/zapisy/apps/notifications/urls.py
+++ b/zapisy/apps/notifications/urls.py
@@ -7,7 +7,6 @@ from . import views
 app_name = "notifications"
 urlpatterns = [
     path('get', views.get_notifications, name='get_notifications'),
-    path('count', views.get_counter, name='get_counter'),
     path('delete', views.delete_one, name='delete-one-notification'),
     path('delete/all', views.delete_all, name='delete-all-notifications'),
     path('preferences/save', views.preferences_save, name='preferences-save'),

--- a/zapisy/apps/notifications/views.py
+++ b/zapisy/apps/notifications/views.py
@@ -22,11 +22,11 @@ from libs.ajax_messages import AjaxFailureMessage
 @login_required
 def get_notifications(request):
     DATE_TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
-    now = datetime.now()
     repo = get_notifications_repository()
     notifications = [{
         'id': notification.id,
-        'description': render_description(notification.description_id, notification.description_args),
+        'description': render_description(notification.description_id,
+                                          notification.description_args),
         'issued_on': notification.issued_on.strftime(DATE_TIME_FORMAT),
         'target': notification.target,
     } for notification in repo.get_all_for_user(request.user)]
@@ -36,14 +36,6 @@ def get_notifications(request):
         d.update({'key': i})
 
     return JsonResponse(notifications, safe=False)
-
-
-@login_required
-def get_counter(request):
-    repo = get_notifications_repository()
-    notification_counter = repo.get_count_for_user(request.user)
-
-    return JsonResponse(notification_counter, safe=False)
 
 
 @require_POST
@@ -78,10 +70,8 @@ def create_form(request):
 @require_POST
 def delete_all(request):
     """Removes all user's notifications"""
-
-    now = datetime.now()
     repo = get_notifications_repository()
-    repo.remove_all_older_than(request.user, now)
+    repo.remove_all(request.user)
 
     return get_notifications(request)
 

--- a/zapisy/apps/notifications/views.py
+++ b/zapisy/apps/notifications/views.py
@@ -22,8 +22,8 @@ from libs.ajax_messages import AjaxFailureMessage
 @login_required
 def get_notifications(request):
     def trunc(text):
-        """Cuts text at 100 characters and ads dots if it was indeed longer."""
-        return text[:100] + (text[100:] and '...')
+        """Cuts text at 200 characters and ads dots if it was indeed longer."""
+        return text[:200] + (text[200:] and '...')
 
     DATE_TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
     repo = get_notifications_repository()

--- a/zapisy/apps/notifications/views.py
+++ b/zapisy/apps/notifications/views.py
@@ -21,12 +21,16 @@ from libs.ajax_messages import AjaxFailureMessage
 
 @login_required
 def get_notifications(request):
+    def trunc(text):
+        """Cuts text at 100 characters and ads dots if it was indeed longer."""
+        return text[:100] + (text[100:] and '...')
+
     DATE_TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
     repo = get_notifications_repository()
     notifications = [{
         'id': notification.id,
-        'description': render_description(notification.description_id,
-                                          notification.description_args),
+        'description': trunc(
+            render_description(notification.description_id, notification.description_args)),
         'issued_on': notification.issued_on.strftime(DATE_TIME_FORMAT),
         'target': notification.target,
     } for notification in repo.get_all_for_user(request.user)]

--- a/zapisy/apps/notifications/views.py
+++ b/zapisy/apps/notifications/views.py
@@ -1,28 +1,22 @@
 from datetime import datetime
 
-import json
-from django.core.serializers.json import DjangoJSONEncoder
-
-from django.shortcuts import render
 from django.contrib import messages
-from django.shortcuts import redirect
 from django.http import HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_POST
 from apps.notifications.forms import PreferencesFormStudent, PreferencesFormTeacher
 from apps.notifications.models import NotificationPreferencesStudent, NotificationPreferencesTeacher
-from apps.notifications.repositories import get_notifications_repository, RedisNotificationsRepository
+from apps.notifications.repositories import get_notifications_repository
 from apps.notifications.utils import render_description
 from apps.users import views
 from apps.users.models import BaseUser
-from libs.ajax_messages import AjaxFailureMessage
 
 
 @login_required
 def get_notifications(request):
     def trunc(text):
-        """Cuts text at 200 characters and ads dots if it was indeed longer."""
+        """Cuts text at 200 characters and adds dots if it was indeed longer."""
         return text[:200] + (text[200:] and '...')
 
     DATE_TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'

--- a/zapisy/assets/common/icons-library.ts
+++ b/zapisy/assets/common/icons-library.ts
@@ -7,10 +7,7 @@
 import { library, dom } from "@fortawesome/fontawesome-svg-core";
 
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt";
-import { faBell as fasBell } from "@fortawesome/free-solid-svg-icons/faBell"
-import { faBell as farBell } from "@fortawesome/free-regular-svg-icons/faBell"
 library.add(faExternalLinkAlt);
-library.add(fasBell, farBell);
 
 // This allows us to include an icon with <i class="fa fa-[ICON-NAME]"></i>.
 dom.watch();

--- a/zapisy/package.json
+++ b/zapisy/package.json
@@ -38,6 +38,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.18",
     "@fortawesome/free-regular-svg-icons": "^5.9.0",
     "@fortawesome/free-solid-svg-icons": "^5.8.2",
+    "@fortawesome/vue-fontawesome": "^0.1.7",
     "@types/bootstrap": "^4.1.2",
     "@types/glob": "^5.0.33",
     "@types/jquery": "^3.3.4",

--- a/zapisy/yarn.lock
+++ b/zapisy/yarn.lock
@@ -38,6 +38,11 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.19"
 
+"@fortawesome/vue-fontawesome@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.7.tgz#121867297cafd141af78c67d92ab9f1ad4b7328b"
+  integrity sha512-YCw2Q2m4fxzyFsPOH3uDYMoJztTD+pT+AAyse4LFpbdrBg+r8ueaVT8BFnXEjrGwMDJJeXrwJ5AOC6q/JWBI4w==
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"


### PR DESCRIPTION
Wprowadza drobne modyfikacje w nowej aplikacji powiadomień.

1. Dodaje etykietkę z liczbą powiadomień, dzięki czemu będzie nieco jaśniejsze, że powiadomienia są.

| Powiadomienia są | Powiadomień brak |
|-------------------------|-------------------------|
| ![image](https://user-images.githubusercontent.com/5896456/64466999-134f6700-d115-11e9-8f21-fc668ac7f710.png) | ![image](https://user-images.githubusercontent.com/5896456/64466887-96bc8880-d114-11e9-8a0e-59865f82316c.png) |

2. Upraszcza pobieranie i usuwanie powiadomień. Wcześniej widget pobierał co 2 sekundy (!) liczbę powiadomień dla użytkownika z serwera, a dopiero po wciśnięciu dzwoneczka faktycznie prosił serwer o powiadomienia. Teraz po prostu pobieramy co 30 sekund (powinno w zupełności wystarczyć) wszystkie powiadomienia.

    **Uwaga:** Jeśli będzie to generowało problemy wydajnościowe — w co wątpię — można w przyszłości wrócić do pobierania liczby powiadomień. Można też pomyśleć o polityce retencji powiadomień, żeby nie gromadziło się ich zbyt dużo.

    Przy okazji upraszczamy czyszczenie wszystkich powiadomień. Zamiast przeglądać je jedno po drugim wywalamy cały klucz z bazy Redis.

3. Zmieniamy template powiadomienia o nowej wiadomości w aktualnościach, aby treść tej wiadomości pojawiała się w e-mailach. To wymaga włożenia pewnego wysiłku w przycinanie powiadomień wyświetlanych na stronie SZ, bo nie chcemy tych aktualności wyświetlać w całości tam.

4. Oraz parę technicznych zmian: Używanie jednego połączenia z Redisem przy wysyłaniu powiadomienia do dużej grupy użytkowników; Drobne zmiany wizualne; Wysyłanie powiadomienia o powstaniu nowej grupy zajęciowej także do studentów zakolejkowanych na zajęcia. 
