### PR TITLE
Rate limiting when sending emails.

### DIFF
--- a/zapisy/apps/notifications/tasks.py
+++ b/zapisy/apps/notifications/tasks.py
@@ -1,5 +1,7 @@
+import time
+
 from django.conf import settings
-from django.core.mail import send_mail
+from django.core.mail import send_mass_mail
 from django.template.loader import render_to_string
 from django_rq import job
 
@@ -8,15 +10,17 @@ from apps.notifications.utils import render_description
 from apps.notifications.models import NotificationPreferencesStudent, NotificationPreferencesTeacher
 from apps.users.models import BaseUser
 
+THROTTLE_SECONDS = 30
+
 
 @job('dispatch-notifications')
 def dispatch_notifications_task(user):
     """Dispatch all pending notifications for the given user by email.
 
-    It's purposely designed around processing all notification_s_
-    at a time instead of handling them one by one
-    so we can introduce a rate-limit and/or batch them together
-    should there ever be a need to do so.
+    We batch all the e-mails for the user together and send them using one SMTP
+    connection. We also wait for THROTTLE_SECONDS until we let the next task in
+    the work queue to send emails. This rate limiting is introduced for Gmail to
+    accept our queries.
     """
     if BaseUser.is_employee(user):
         model, created = NotificationPreferencesTeacher.objects.get_or_create(user=user)
@@ -25,7 +29,10 @@ def dispatch_notifications_task(user):
 
     repo = get_notifications_repository()
     pending_notifications = repo.get_unsent_for_user(user)
+    if not pending_notifications:
+        return
 
+    messages = []
     for pn in pending_notifications:
         # User controls in account settings
         # what notifications will be send
@@ -38,10 +45,16 @@ def dispatch_notifications_task(user):
             'greeting': f'Dzień dobry, {user.first_name}',
         }
 
-        send_mail(
+        messages.append((
             'Wiadomość od Systemu Zapisów IIUWr',  # FIXME (?)
             render_to_string('notifications/email_base.html', ctx),
             settings.MASS_MAIL_FROM,
-            [user.email])
+            [user.email],
+        ))
+    send_mass_mail(messages, fail_silently=False)
 
+    # Only mark the notifications as sent if the e-mails went out successfully.
+    for pn in pending_notifications:
         repo.mark_as_sent(user, pn)
+
+    time.sleep(THROTTLE_SECONDS)


### PR DESCRIPTION
We introduce some rate-limiting and connection reusal when sending
e-mails. It is motivated by Gmail blocking our requests.