### PR TITLE
Czytanie EMAIL_THROTTLE_SECONDS ze zmiennej środowiskowej.

### DIFF
--- a/zapisy/apps/notifications/tasks.py
+++ b/zapisy/apps/notifications/tasks.py
@@ -10,8 +10,6 @@ from apps.notifications.utils import render_description
 from apps.notifications.models import NotificationPreferencesStudent, NotificationPreferencesTeacher
 from apps.users.models import BaseUser
 
-THROTTLE_SECONDS = 30
-
 
 @job('dispatch-notifications')
 def dispatch_notifications_task(user):
@@ -36,7 +34,7 @@ def dispatch_notifications_task(user):
     for pn in pending_notifications:
         # User controls in account settings
         # what notifications will be send
-        if not getattr(model, pn.description_id):
+        if not getattr(model, pn.description_id, None):
             continue
 
         ctx = {
@@ -57,4 +55,4 @@ def dispatch_notifications_task(user):
     for pn in pending_notifications:
         repo.mark_as_sent(user, pn)
 
-    time.sleep(THROTTLE_SECONDS)
+    time.sleep(settings.EMAIL_THROTTLE_SECONDS)

--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -24,6 +24,7 @@ EMAIL_HOST_USER = env.str('EMAIL_HOST_USER', default='')
 EMAIL_HOST_PASSWORD = env.str('EMAIL_HOST_PASSWORD', default='')
 EMAIL_PORT = env.int('EMAIL_PORT', default=25)
 SERVER_EMAIL = env.str('SERVER_EMAIL', default='root@localhost')
+EMAIL_THROTTLE_SECONDS = env.int('EMAIL_THROTTLE_SECONDS', default=0)
 
 # django-environ doesn't support nested arrays, but decoding json objects works fine
 ARRAY_VALS = env.json('ARRAY_VALS', {})


### PR DESCRIPTION
Główną motywacją dla tej zmiany jest fakt, że jeśli
`EMAIL_THROTTLE_SECONDS` jest ustawione w kodzie na 30 sekund, testy
zabierają strasznie dużo czasu.