### PR TITLE
Usuwa tagi z wysyłanych maili.

### DIFF
--- a/zapisy/apps/notifications/tasks.py
+++ b/zapisy/apps/notifications/tasks.py
@@ -3,6 +3,7 @@ import time
 from django.conf import settings
 from django.core.mail import send_mass_mail
 from django.template.loader import render_to_string
+from django.utils.html import strip_tags
 from django_rq import job
 
 from apps.notifications.repositories import get_notifications_repository
@@ -24,8 +25,10 @@ def dispatch_notifications_task(user):
     """
     if BaseUser.is_employee(user):
         model, created = NotificationPreferencesTeacher.objects.get_or_create(user=user)
-    else:
+    elif BaseUser.is_student(user):
         model, created = NotificationPreferencesStudent.objects.get_or_create(user=user)
+    else:
+        return
 
     repo = get_notifications_repository()
     pending_notifications = repo.get_unsent_for_user(user)
@@ -45,9 +48,10 @@ def dispatch_notifications_task(user):
             'greeting': f'Dzień dobry, {user.first_name}',
         }
 
+        message_contents = render_to_string('notifications/email_base.html', ctx)
         messages.append((
-            'Wiadomość od Systemu Zapisów IIUWr',  # FIXME (?)
-            render_to_string('notifications/email_base.html', ctx),
+            'Wiadomość od Systemu Zapisów IIUWr',
+            strip_tags(message_contents),
             settings.MASS_MAIL_FROM,
             [user.email],
         ))

--- a/zapisy/apps/notifications/tests/test_emails.py
+++ b/zapisy/apps/notifications/tests/test_emails.py
@@ -1,6 +1,7 @@
 from django.core import mail
 from django.template.loader import render_to_string
 from django.test import TestCase, override_settings
+from django.utils.html import strip_tags
 
 from apps.enrollment.courses.models.group import Group
 from apps.enrollment.courses.tests.factories import GroupFactory
@@ -29,5 +30,5 @@ class NotificationsEmailTestCase(TestCase):
             f'Dzień dobry, {teacher.user.first_name}',
         }
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].body, render_to_string('notifications/email_base.html',
-                                                               ctx))
+        self.assertEqual(mail.outbox[0].body,
+                         strip_tags(render_to_string('notifications/email_base.html', ctx)))


### PR DESCRIPTION
Ostatnio wysłane maile zawierały tagi HTML. W niniejszej zmianie
naprawiamy ten błąd za pomocą funkcji `strip_tags`.