### PR TITLE
Zacieśnia czasy T0

### DIFF
--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -275,7 +275,7 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 # Settings for enrollment.
 # Bonus minutes per one ECTS credit. This setting affects T0 times computation.
-ECTS_BONUS = 5
+ECTS_BONUS = 2
 # Limits concerning the amount of ECTS points a student can sign up to in a
 # semester. For the first part of enrollment cycle, the INITIAL_LIMIT holds.
 # Then, after abolition time, students can enroll into some additional courses.
@@ -283,9 +283,6 @@ ECTS_INITIAL_LIMIT = 35
 ECTS_FINAL_LIMIT = 45
 
 VOTE_LIMIT = 60
-
-LETURE_TYPE = '1'
-QUEUE_PRIORITY_LIMIT = 5
 
 SESSION_COOKIE_PATH = '/;HttpOnly'
 SESSION_COOKIE_SECURE = env.bool('SESSION_COOKIE_SECURE', default=False)


### PR DESCRIPTION
W najbliższym semestrze mamy potrzebę zacieśnienia czasów T0 studentów,
by zmieścić całe zapisy pomiędzy ogłoszeniem wyników rekrutacji a
początkiem semestru. Realizujemy to zacieśnienie poprzez zmniejszenie
bonusu wynikającego z zarobienia 1 punktu ECTS z 5 do 2 minut.

Przy okazji usuwamy dwa nieużywane ustawienia z pliku settings.py.