### PR TITLE
Uważne parsowanie JSONa z powiadomieniami.

### DIFF
--- a/zapisy/apps/notifications/views.py
+++ b/zapisy/apps/notifications/views.py
@@ -30,9 +30,6 @@ def get_notifications(request):
     } for notification in repo.get_all_for_user(request.user)]
     notifications.sort(key=lambda x: x['issued_on'], reverse=True)
 
-    for (i, d) in enumerate(notifications):
-        d.update({'key': i})
-
     return JsonResponse(notifications, safe=False)
 
 

--- a/zapisy/package.json
+++ b/zapisy/package.json
@@ -72,6 +72,7 @@
     "postcss-loader": "^3.0.0",
     "precss": "^4.0.0",
     "sass-loader": "^6.0.6",
+    "spicery": "^1.1.0",
     "style-loader": "^0.21.0",
     "terser-webpack-plugin": "^1.1.0",
     "ts-loader": "^4.4.1",

--- a/zapisy/yarn.lock
+++ b/zapisy/yarn.lock
@@ -5986,6 +5986,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz#75ecd1a88de8c184ef015eafb51b5b48bfd11bb1"
   integrity sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==
 
+spicery@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/spicery/-/spicery-1.1.0.tgz#a57bfdc5a6fadaf5a200645a60d75c5cb3efd15b"
+  integrity sha1-pXv9xab62vWiAGRaYNdcXLPv0Vs=
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"


### PR DESCRIPTION
Niniejsza zmiana naprawia dość egzotyczny błąd (#757) wynikający z
braku typów w JavaScripcie: Gdy użytkownik ma stronę Systemu Zapisów
otwartą w dwóch kartach, w jednej się wyloguje, a widget powiadomień
ciągle prosi o powiadomienia w drugiej karcie. Serwer wysyła wtedy,
zamiast JSONa z powiadomieniami, stronę logowania.

Niestety, mimo że widget został napisany w TypeScripcie i typy są dobrze
zdefiniowane, cała wiedza o typach znika, skrypt zapisuje
stronę logowania (ciąg znaków) w zmiennej, w której powinna być lista
powiadomień, a następnie Vue próbuje (reaktywnie) skonsumować te dane,
myśląc, że jest to uczciwa lista powiadomień. Jest to operacja tak
skomplikowana i nieprzewidywalna, że przeglądarka zużywa całe dostępne
zasoby i wszystko się wiesza na amen.

By zaradzić takim przypadkom używamy paczki _spicery_, która pozwala
bardziej rygorystycznie parsować dane z serwera. Jeśli to, co serwer nam
przysłał nie jest listą powiadomień, widget rzuci błędem, tak jak się to
powinno dziać.

-- 

Fixes #757.