### PR TITLE
Skrypty na okoliczność zapisów studentów pierwszego roku

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb|
     # Customize the amount of memory on the VM:
-    vb.memory = "1024"
+    vb.memory = "4096"
     # The folder "node_modules" will live somewhere else and only be mounted
     # in /vagrant/zapisy to avoid the issue with symlinks on Windows.
     config.vm.provision "shell", inline: <<-SHELL

--- a/zapisy/apps/enrollment/records/models/opening_times.py
+++ b/zapisy/apps/enrollment/records/models/opening_times.py
@@ -246,7 +246,8 @@ class GroupOpeningTimes(models.Model):
             T0Times.objects.filter(semester_id=group.course.semester_id).values_list(
                 "student_id", "time"))
         # We also need votes for the course.
-        votes = SingleVote.objects.meaningful().in_semester(semester=group.course.semester).filter(proposal=group.course.offer)
+        votes = SingleVote.objects.meaningful().in_semester(semester=group.course.semester).filter(
+            proposal=group.course.offer)
         opening_time_objects: List['GroupOpeningTimes'] = []
         single_vote: SingleVote
         for single_vote in votes:

--- a/zapisy/apps/enrollment/records/models/opening_times.py
+++ b/zapisy/apps/enrollment/records/models/opening_times.py
@@ -246,7 +246,7 @@ class GroupOpeningTimes(models.Model):
             T0Times.objects.filter(semester_id=group.course.semester_id).values_list(
                 "student_id", "time"))
         # We also need votes for the course.
-        votes = SingleVote.objects.filter(proposal=group.course.offer)
+        votes = SingleVote.objects.meaningful().in_semester(semester=group.course.semester).filter(proposal=group.course.offer)
         opening_time_objects: List['GroupOpeningTimes'] = []
         single_vote: SingleVote
         for single_vote in votes:

--- a/zapisy/apps/schedulersync/management/commands/import_schedule.py
+++ b/zapisy/apps/schedulersync/management/commands/import_schedule.py
@@ -31,7 +31,6 @@ LIMITS = {'1': 300, '9': 300, '2': 20, '3': 15, '5': 18, '6': 15, '10': 15}
 EMPLOYEE_MAP = {
     'PLISOWSKI': '258497',
     'PRATIKGHOSAL': '268909',
-    'AHOFFMANN': 'NN',
     'AMORAWIEC': 'NN',
     'AMALINOWSKI': 'NN',
     'ARACZYNSKI': 'NN',
@@ -42,15 +41,15 @@ EMPLOYEE_MAP = {
     'JDYMARA': 'NN',
     'JDZIUBANSKI': 'NN',
     'LNEWELSKI': 'NN',
-    'MDROFISZYN': 'NN',
     'MPREISNER': 'NN',
     'PKOWALSKI': 'NN',
     'RSZWARC': 'NN',
     'SCYGAN': 'NN',
     'TELSNER': 'NN',
     'TRZEPECKI': 'NN',
-    'WHEBISCH': 'NN',
-    'NN1': 'NN'
+    '5323': 'PAWEL.LASKOS-GRABOWSKI',
+    'NN1': 'NN',
+    'IM': 'NN',
 }
 
 COURSES_MAP = {
@@ -90,7 +89,8 @@ COURSES_DONT_IMPORT = [
     'RÓWNANIA RÓŻNICZKOWE 1',
     'RÓWNANIA RÓŻNICZKOWE 1R',
     'TEORIA PRAWDOPODOBIEŃSTWA 1',
-    'TOPOLOGIA']
+    'TOPOLOGIA',
+    'INSTYTUT MATEMATYCZNY']
 
 
 class Command(BaseCommand):

--- a/zapisy/scripts/clear_queues.py
+++ b/zapisy/scripts/clear_queues.py
@@ -14,11 +14,11 @@ def run():
     ]
     course_groups = Group.objects.filter(course__slug__in=course_slugs)
     roles = AuthGroup.objects.filter(name__in=turns)
-    Record.objects.filter(group__in=course_groups,status=RecordStatus.QUEUED).delete()
+    Record.objects.filter(group__in=course_groups, status=RecordStatus.QUEUED).delete()
     for gr in course_groups:
         limit = gr.limit
-        for gs in GuaranteedSpots.objects.filter(group=gr,role__in=roles):
+        for gs in GuaranteedSpots.objects.filter(group=gr, role__in=roles):
             limit = limit + gs.limit
-        GuaranteedSpots.objects.filter(group=gr,role__in=roles).delete()
+        GuaranteedSpots.objects.filter(group=gr, role__in=roles).delete()
         gr.limit = limit
         gr.save()

--- a/zapisy/scripts/clear_queues.py
+++ b/zapisy/scripts/clear_queues.py
@@ -1,0 +1,24 @@
+from apps.enrollment.courses.models import Group
+from apps.enrollment.records.models import Record, RecordStatus
+from apps.enrollment.courses.models.group import GuaranteedSpots
+from django.contrib.auth.models import Group as AuthGroup
+
+
+def run():
+    turns = ['tura1', 'tura2', 'tura3']
+    course_slugs = [
+        'analiza-matematyczna-201920-zimowy', 'kurs-podstawowy-warsztat-informatyka-201920-zimowy',
+        'kurs-wstep-do-programowania-w-jezyku-c-201920-zimowy',
+        'kurs-wstep-do-programowania-w-jezyku-python-201920-zimowy',
+        'wstep-do-informatyki-201920-zimowy'
+    ]
+    course_groups = Group.objects.filter(course__slug__in=course_slugs)
+    roles = AuthGroup.objects.filter(name__in=turns)
+    Record.objects.filter(group__in=course_groups,status=RecordStatus.QUEUED).delete()
+    for gr in course_groups:
+        limit = gr.limit
+        for gs in GuaranteedSpots.objects.filter(group=gr,role__in=roles):
+            limit = limit + gs.limit
+        GuaranteedSpots.objects.filter(group=gr,role__in=roles).delete()
+        gr.limit = limit
+        gr.save()

--- a/zapisy/scripts/mass_opening.py
+++ b/zapisy/scripts/mass_opening.py
@@ -8,9 +8,9 @@ from apps.users.models import Student
 def run():
     turns = ['tura1', 'tura2', 'tura3']
     opening_times = {
-        'tura1': datetime.datetime(2019, 10, 1, 13, 30),
-        'tura2': datetime.datetime(2019, 10, 1, 14, 0),
-        'tura3': datetime.datetime(2019, 10, 1, 14, 30),
+        'tura1': datetime.datetime(2019, 10, 1, 14, 0),
+        'tura2': datetime.datetime(2019, 10, 1, 14, 30),
+        'tura3': datetime.datetime(2019, 10, 1, 15, 0),
     }
 
     course_slugs = [

--- a/zapisy/scripts/single_opening.py
+++ b/zapisy/scripts/single_opening.py
@@ -1,0 +1,21 @@
+import datetime
+
+from apps.enrollment.courses.models import Group
+from apps.enrollment.records.models import GroupOpeningTimes
+from apps.users.models import Student
+
+
+def run():
+    course_slugs = [
+        'analiza-matematyczna-201920-zimowy', 'kurs-podstawowy-warsztat-informatyka-201920-zimowy',
+        'kurs-wstep-do-programowania-w-jezyku-c-201920-zimowy',
+        'kurs-wstep-do-programowania-w-jezyku-python-201920-zimowy',
+        'wstep-do-informatyki-201920-zimowy'
+    ]
+    course_groups = Group.objects.filter(course__slug__in=course_slugs)
+
+    student = Student.objects.get(matricula='314308')
+    time = datetime.datetime(2019, 10, 1, 15, 0)
+
+    for group in course_groups:
+        GroupOpeningTimes.objects.create(student=student, group=group, time=time)


### PR DESCRIPTION
1. Więcej pamięci dla Vagranta, żeby mógł kompilować JS-y.
2. Parę skryptów związanych z zapisami dla I roku.
3. Nowe regułki w skrypcie do importowania planu.
4. Bugfix: Funkcja `populate_single_group_opening_times` niepoprawnie zliczała bonusy za głosowanie.