### PR TITLE
Usuwamy flexboxa z layout'u do drukowania.

### DIFF
--- a/zapisy/assets/common/index.scss
+++ b/zapisy/assets/common/index.scss
@@ -29,6 +29,16 @@ a {
   cursor: pointer;
 }
 
+@media print {
+  // Some browsers do not handle printing layouts with flexbox. This should be
+  // fixed in Bootstrap.
+  // https://github.com/twbs/bootstrap/issues/26781
+  .row,
+  .form-row {
+    display: block;
+  }
+}
+
 .right {
   float: right;
 }

--- a/zapisy/templates/base.html
+++ b/zapisy/templates/base.html
@@ -8,7 +8,7 @@
 {% load render_bundle from webpack_loader %}
 
 <!DOCTYPE html>
-<html lang="pl" class="h-100">
+<html lang="pl">
 
 <head>
     <meta charset="utf-8">
@@ -41,7 +41,7 @@
     
 </head>
 
-<body class="d-flex flex-column h-100">
+<body>
     <div class="container-fluid p-0 d-print-none">
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
@@ -226,7 +226,7 @@
     </div>
     {% block rendered_bundles %}
     {% endblock %}
-    <footer class="mt-auto d-print-none">
+    <footer class="d-print-none">
         <div class="container-fluid">
             <div class="container">
                 <p>


### PR DESCRIPTION
Niektóre niszowe przeglądarki (Firefox, IE) zupełnie nie radzą sobie z drukowaniem stron, na których użyto flexboxa (narzędzia w CSS). Na ich użytek trzeba więc usunąć flexboxa ze stylów, które stosowane są przy drukowaniu, jak najmniej przy tym demolując stronę.

## Działanie zmian przy drukowaniu sylabusa w przeglądarce Firefox
Przed | Po
-------- | ---
![image](https://user-images.githubusercontent.com/5896456/66416919-306ea280-e9ff-11e9-993f-3a8dd2ba7460.png)![image](https://user-images.githubusercontent.com/5896456/66416983-55fbac00-e9ff-11e9-8695-cbe06683110d.png) | ![image](https://user-images.githubusercontent.com/5896456/66417010-64e25e80-e9ff-11e9-957f-730d0589ae77.png) ![image](https://user-images.githubusercontent.com/5896456/66417028-6d3a9980-e9ff-11e9-9a7a-d48c8788cb57.png)

---

## O błędzie
[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1089549
> Even this Bugzilla page itself cannot be printed with Firefox, only 1 page gets printed and rest is truncated. All the other browsers seem to work correctly with this. Maybe this bug should be higher priority than 4? A lot has happened since this bug was reported and Flexbox is really popular these days with Bootstrap and all using it.

[2] https://github.com/twbs/bootstrap/issues/26781