### PR TITLE
Nazwa prowadzącego grupy jest linkiem do jego profilu

### DIFF
--- a/zapisy/apps/enrollment/courses/templates/courses/group.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/group.html
@@ -35,7 +35,13 @@
     <header class="d-flex justify-content-between align-items-center">
         <div>
             <h1>{{ group.course }}</h1>
-            <h4>{{group.get_type_display}}: {{group.get_teacher_full_name}}</h4>
+            <h4>{{group.get_type_display}}:
+                    {% if group.teacher %}
+                        <a href="{% url 'employee-profile' group.teacher.user_id %}"
+                        class="person">{{group.get_teacher_full_name}}</a>
+                    {% else %}
+                        (nieznany prowadzący)
+                    {% endif %}</h4>
             <h6>{% for term in group.term.all %}{{ term }}{% endfor %}</h6>
         </div>
         {% if user.is_staff %}


### PR DESCRIPTION
Na stronie z listą osób zapisanych na zajęcia, imię i nazwisko osoby prowadzącej grupę  jest od teraz linkiem do jej profilu. 

Resolves #773 