### PR TITLE
Poprawne plany zajęć studento-pracowników

### DIFF
--- a/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
+++ b/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
@@ -27,9 +27,9 @@
 
 {% block content %}
     <div class="row" id="timetable"></div>
-    <script id="timetable-data" type="application/json">{{ groups_json|safe }}</script>
-    <script id="courses-list" type="application/json">{{ courses_json|safe }}</script>
-    <script id="filters-data" type="application/json">{{ filters_json|safe }}</script>
+    {{ groups_json|json_script:"timetable-data" }}
+    {{ courses_json|json_script:"courses-list" }}
+    {{ filters_json|json_script:"filters-data" }}
     <input id="prototype-update-url" type="hidden" value="{% url 'prototype-update' %}">
 
     <div class="mt-3 border-top pt-3">

--- a/zapisy/apps/enrollment/timetable/templates/timetable/timetable.html
+++ b/zapisy/apps/enrollment/timetable/templates/timetable/timetable.html
@@ -25,7 +25,7 @@
     </p>
     <div class="row m-0" id="timetable">
     </div>
-    <script id="timetable-data" type="application/json">{{ groups_json|safe }}</script>
+    {{ groups_dicts|json_script:"timetable-data" }}
     {% render_bundle 'timetable-timetable-component' %}
     
     {% if user.student %}

--- a/zapisy/apps/enrollment/timetable/views.py
+++ b/zapisy/apps/enrollment/timetable/views.py
@@ -103,7 +103,7 @@ def student_timetable_data(student: Student):
     data = {
         'groups': groups,
         'sum_points': sum(points_for_courses.values()),
-        'groups_json': json.dumps(group_dicts, cls=DjangoJSONEncoder),
+        'groups_dicts': group_dicts,
     }
     return data
 
@@ -116,7 +116,7 @@ def employee_timetable_data(employee: Employee):
             'term', 'term__classrooms', 'guaranteed_spots', 'guaranteed_spots__role')
     group_dicts = build_group_list(groups)
     data = {
-        'groups_json': json.dumps(group_dicts, cls=DjangoJSONEncoder),
+        'groups_dicts': group_dicts,
     }
     return data
 

--- a/zapisy/apps/enrollment/timetable/views.py
+++ b/zapisy/apps/enrollment/timetable/views.py
@@ -4,12 +4,11 @@ import csv
 import json
 from typing import List
 
-from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count, Q
 from django.forms.models import model_to_dict
 from django.http import JsonResponse
-from django.shortcuts import Http404, HttpResponse, redirect, render
+from django.shortcuts import Http404, HttpResponse, render
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 


### PR DESCRIPTION
Studento-pracownicy widzą teraz w swoim planie zarówno przedmioty, w których uczestniczą, jak i te, które prowadzą.

Fixes #768 