### PR TITLE
Poprawne sortowanie listy studentów zapisanych do grupy

### DIFF
--- a/zapisy/apps/enrollment/courses/templates/courses/group.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/group.html
@@ -63,7 +63,7 @@
         </p>
 
         {% if students_in_group %}
-            {% include "courses/students_list.html" with students=students_in_group|dictsort:"user.last_name" %}
+            {% include "courses/students_list.html" with students=students_in_group %}
             
             {% if request.user.is_staff or request.user.employee %}
             <div class="d-print-none">

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -162,18 +162,17 @@ def group_view(request, group_id):
 
     guaranteed_spots_rules = GuaranteedSpots.objects.filter(group=group)
 
-    students_in_group = []
-    students_in_queue = []
-
-    def handle_records(records, student_list):
+    def collect_students(records) -> List[Student]:
         record: Record
+        student_list = []
         for record in records:
             record.student.guaranteed = set(rule.role.name for rule in guaranteed_spots_rules) & set(
                 role.name for role in record.student.user.groups.all())
             student_list.append(record.student)
+        return student_list
 
-    handle_records(records_group, students_in_group)
-    handle_records(records_queue, students_in_queue)
+    students_in_group = collect_students(records_group)
+    students_in_queue = collect_students(records_queue)
 
     data = {
         'students_in_group': students_in_group,

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -128,24 +128,37 @@ def group_view(request, group_id):
         ).prefetch_related('term', 'term__classroom').get(id=group_id)
     except Group.DoesNotExist:
         raise Http404
+    
+    order = Func(
+    'student__user__last_name',
+    function='pl_PL',
+    template='lower(%(expressions)s) COLLATE "%(function)s"')
 
-    records = Record.objects.filter(
-        group_id=group_id).exclude(status=RecordStatus.REMOVED).select_related(
+    records_group = Record.objects.filter(
+        group_id=group_id, status=RecordStatus.ENROLLED).select_related(
+            'student', 'student__user', 'student__program',
+            'student__consent').prefetch_related('student__user__groups').order_by(order)
+    
+    records_queue = Record.objects.filter(
+        group_id=group_id, status=RecordStatus.QUEUED).select_related(
             'student', 'student__user', 'student__program',
             'student__consent').prefetch_related('student__user__groups').order_by('created')
-
+    
     guaranteed_spots_rules = GuaranteedSpots.objects.filter(group=group)
 
     students_in_group = []
     students_in_queue = []
+    
     record: Record
-    for record in records:
+    for record in records_group:
         record.student.guaranteed = set(rule.role.name for rule in guaranteed_spots_rules) & set(
             role.name for role in record.student.user.groups.all())
-        if record.status == RecordStatus.ENROLLED:
-            students_in_group.append(record.student)
-        elif record.status == RecordStatus.QUEUED:
-            students_in_queue.append(record.student)
+        students_in_group.append(record.student)
+    for record in records_queue:
+        record.student.guaranteed = set(rule.role.name for rule in guaranteed_spots_rules) & set(
+            role.name for role in record.student.user.groups.all())
+        students_in_queue.append(record.student)
+    
     data = {
         'students_in_group': students_in_group,
         'students_in_queue': students_in_queue,

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -136,10 +136,10 @@ def group_view(request, group_id):
     #
     # In this case, we simply ask our database (through Django) to run a query:
     # SELECT ... FROM ...
-    #  . 
-    #  .  
+    #  .
+    #  .
     # ORDER BY student__user__last_name COLLATE pl_PL
-    # 
+    #
     # It will work in any database supporting COLLATE (both PostgreSQL and MySQL
     # do) however the locale specification may differ.
     order = Func(

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -130,25 +130,22 @@ def group_view(request, group_id):
     except Group.DoesNotExist:
         raise Http404
 
+    # ORDER BY will sort records depending on the database locale (collation).
+    # We can either make sure that database uses the locale we need or ask for
+    # proper collation in sql queries.
+    #
+    # In this case, we simply ask our database (through Django) to run a query:
+    # SELECT ... FROM ...
+    #  . 
+    #  .  
+    # ORDER BY student__user__last_name COLLATE pl_PL
+    # 
+    # It will work in any database supporting COLLATE (both PostgreSQL and MySQL
+    # do) however the locale specification may differ.
     order = Func(
         'student__user__last_name',
         function='pl_PL',
         template='(%(expressions)s) COLLATE "%(function)s"')
-
-    """
-        ORDER BY will sort records depending on the database locale (collation).
-        We can either make sure that database uses the locale we need or
-        ask for proper collation in sql queries.
-
-        In this case, we simply ask our database (through Django) to run a query:
-        SELECT ... FROM ...
-        .
-        .
-        .
-        ORDER BY student__user__last_name COLLATE pl_PL
-
-        It will work in any database supporting COLLATE (both PostgreSQL and MySQL do).
-    """
 
     records_group = Record.objects.filter(
         group_id=group_id, status=RecordStatus.ENROLLED).select_related(

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -135,11 +135,11 @@ def group_view(request, group_id):
         function='pl_PL',
         template='(%(expressions)s) COLLATE "%(function)s"')
 
-    """ 
+    """
         ORDER BY will sort records depending on the database locale (collation).
         We can either make sure that database uses the locale we need or
-        ask for proper collation in sql queries. 
-        
+        ask for proper collation in sql queries.
+
         In this case, we simply ask our database (through Django) to run a query:
         SELECT ... FROM ...
         .


### PR DESCRIPTION
Lista studentów zapisanych do grupy jest teraz posortowana alfabetycznie, z uwzględnieniem polskich znaków. Sortowanie odbywa się po stronie bazy danych, nie zaś samej aplikacji.

Fixes #769 