### PR TITLE
Dodano opcję mailto dla pracowników do głosujących na propozycję

### DIFF
--- a/zapisy/apps/enrollment/utils.py
+++ b/zapisy/apps/enrollment/utils.py
@@ -43,6 +43,7 @@ def send_mail(msg_parts, user):
 def mailto(author, students, bcc=False):
     """Helper method to create mailto links"""
     result = author.email
+
     if students:
         return result + ('?bcc=' if bcc else ',') + \
             ','.join([student.user.email.replace('+', '%2B') for student in students])

--- a/zapisy/apps/offer/vote/templates/vote/proposal_summary.html
+++ b/zapisy/apps/offer/vote/templates/vote/proposal_summary.html
@@ -41,6 +41,15 @@
                     {% endfor %}
                 </tbody>
             </table>
+            {% if request.user.is_staff or request.user.employee %}
+                <div class="d-print-none">
+                    <h5>Wyślij wiadomość do głosujących</h5>
+                    <ul>
+                        <li><a href="mailto:{{ mailto_voters }}">udostępniając adresy mailowe studentów</a></li>
+                        <li><a href="mailto:{{ mailto_voters_bcc }}">ukrywając adresy mailowe studentów</a></li>
+                    </ul>
+                </div>
+            {% endif %}
         {% else %}
             <div class="alert alert-warning">Nikt nie zagłosował na ten przedmiot.</div>
         {% endif %}

--- a/zapisy/apps/offer/vote/views.py
+++ b/zapisy/apps/offer/vote/views.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.shortcuts import redirect, render, get_object_or_404
 
 from apps.enrollment.courses.models import Semester
+from apps.enrollment.utils import mailto
 from apps.offer.proposal.models import Proposal, ProposalStatus
 from apps.offer.vote.models import SingleVote, SystemState
 from apps.users.decorators import student_required
@@ -125,8 +126,15 @@ def proposal_vote_summary(request, slug):
 
     total = votes.aggregate(total=models.Sum('true_val')).get('total', 0)
 
+    voters = []
+
+    for vote in votes:
+        voters.append(vote.student)
+
     return render(request, 'vote/proposal_summary.html', {
         'proposal': proposal,
         'votes': votes,
         'total': total,
+        'mailto_voters': mailto(request.user, voters, bcc=False),
+        'mailto_voters_bcc': mailto(request.user, voters, bcc=True)
     })

--- a/zapisy/apps/offer/vote/views.py
+++ b/zapisy/apps/offer/vote/views.py
@@ -126,10 +126,7 @@ def proposal_vote_summary(request, slug):
 
     total = votes.aggregate(total=models.Sum('true_val')).get('total', 0)
 
-    voters = []
-
-    for vote in votes:
-        voters.append(vote.student)
+    voters = [vote.student for vote in votes]
 
     return render(request, 'vote/proposal_summary.html', {
         'proposal': proposal,


### PR DESCRIPTION
W wynikach głosowania na propozycję przedmiotu pracownikom wyświetlają się teraz linki z mailto do głosujących na daną propozycję.

Closes #771 