### PR TITLE
Wyświetlanie daty w kalendarzu aplikacji „Sale”.

### DIFF
--- a/zapisy/apps/schedule/templates/schedule/events.html
+++ b/zapisy/apps/schedule/templates/schedule/events.html
@@ -47,7 +47,7 @@
                 "timeFormat":"HH:mm"
             },
             "day":{
-                "titleFormat":"dddd, d MMM, YYYY",
+                "titleFormat":"dddd, DD MMM, YYYY",
                 "columnFormat":"dddd DD.MM",
                 "timeFormat":"HH:mm"
             }


### PR DESCRIPTION
Zamiast dnia tygodnia (0-6), teraz wyświetlany jest dzień miesiąca (1-31).
Zmieniłem format daty w json
closes #706