### PR TITLE
Remove student and employee groups

### DIFF
--- a/zapisy/apps/offer/vote/tests/test_forms.py
+++ b/zapisy/apps/offer/vote/tests/test_forms.py
@@ -141,7 +141,7 @@ class VoteFormsetTest(test.TestCase):
         # This number is a bit artificial — we just care that it is a constant.
         # I have inspected the queries and they look ok, so this is just
         # supposed to test that no one breaks performance in the future.
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(11):
             response = c.get('/vote/vote/')
         self.assertContains(response, '<select', count=6)
 
@@ -150,7 +150,7 @@ class VoteFormsetTest(test.TestCase):
 
         # Number of queries should not change when we add one more proposal.
         ProposalFactory(status=ProposalStatus.IN_VOTE)
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(11):
             response = c.get('/vote/vote/')
         self.assertContains(response, '<select', count=7)
 

--- a/zapisy/apps/users/models.py
+++ b/zapisy/apps/users/models.py
@@ -65,11 +65,11 @@ class BaseUser(models.Model):
 
     @staticmethod
     def is_student(user: User) -> bool:
-        return is_user_in_group(user, 'students')
+        return hasattr(user, 'student')
 
     @staticmethod
     def is_employee(user: User) -> bool:
-        return is_user_in_group(user, 'employees')
+        return hasattr(user, 'employee')
 
     @staticmethod
     def is_external_contractor(user: User) -> bool:


### PR DESCRIPTION
* Implementation of is_student and is_employee methods now is
independent of student and employee groups.
* Above change has impact on number of queries generated in
test_forms.py - test is corrected