### PR TITLE
Poprawia błędny argument do testu członka komisji.

### DIFF
--- a/zapisy/apps/theses/validators.py
+++ b/zapisy/apps/theses/validators.py
@@ -23,7 +23,7 @@ def validate_master_rejecter(value: Optional[int]):
     if value is not None:
         try:
             person = Employee.objects.get(pk=value)
-            if not is_theses_board_member(person):
+            if not is_theses_board_member(person.user):
                 raise ValidationError(
                     f'{person} nie jest członkiem komisji prac dyplomowych. Skład komisji ' +
                     "definiować można w zakładce Użytkownicy -> Grupy -> Komisja prac dyplomowych."


### PR DESCRIPTION
Błąd opisany w #791 polega na tym, że przy walidacji formularza w panelu
administratora odpalana jest funkcja `validate_master_rejecter`, która
sprawdza, czy użytkownik ustawiony jako _master rejecter_ należy w ogóle
do komisji prac dyplomowych. Zamiast użytkownika podano jednak funkcji
obiekt pracownika. W niniejszej zmianie naprawiamy ten błąd.

Fixes #791.