### PR TITLE
Historia rezerwacji: filtrowanie oraz link w tytule

### DIFF
--- a/zapisy/apps/schedule/filters.py
+++ b/zapisy/apps/schedule/filters.py
@@ -3,13 +3,16 @@ from apps.enrollment.courses.models.semester import Semester
 from apps.schedule.models.event import Event
 from apps.schedule.models.term import Term
 
-FILTER_TYPE_CHOICES = [('', '---------')] + Event.TYPES
-FILTER_STATUS_CHOICES = [('', '---------')] + Event.STATUSES
-
 
 class EventFilter(django_filters.FilterSet):
-    type = django_filters.ChoiceFilter(choices=FILTER_TYPE_CHOICES, label='Typ')
-    status = django_filters.ChoiceFilter(choices=FILTER_STATUS_CHOICES, label='Status')
+    type = django_filters.ChoiceFilter(choices=Event.TYPES,
+                                       label='Typ',
+                                       empty_label="Dowolny")
+    status = django_filters.ChoiceFilter(choices=Event.STATUSES,
+                                         label='Status',
+                                         empty_label="Dowolny")
+    visible = django_filters.ChoiceFilter(choices=Event.BOOLEAN_CHOICES,
+                                          empty_label="Dowolne")
 
     class Meta:
         model = Event

--- a/zapisy/apps/schedule/filters.py
+++ b/zapisy/apps/schedule/filters.py
@@ -3,6 +3,9 @@ from apps.enrollment.courses.models.semester import Semester
 from apps.schedule.models.event import Event
 from apps.schedule.models.term import Term
 
+BOOLEAN_CHOICES = [(True, "Tak"),
+                   (False, "Nie")]
+
 
 class EventFilter(django_filters.FilterSet):
     type = django_filters.ChoiceFilter(choices=Event.TYPES,
@@ -11,7 +14,7 @@ class EventFilter(django_filters.FilterSet):
     status = django_filters.ChoiceFilter(choices=Event.STATUSES,
                                          label='Status',
                                          empty_label="Dowolny")
-    visible = django_filters.ChoiceFilter(choices=Event.BOOLEAN_CHOICES,
+    visible = django_filters.ChoiceFilter(choices=BOOLEAN_CHOICES,
                                           empty_label="Dowolne")
 
     class Meta:

--- a/zapisy/apps/schedule/models/event.py
+++ b/zapisy/apps/schedule/models/event.py
@@ -28,6 +28,9 @@ class Event(models.Model):
                 (STATUS_ACCEPTED, 'Zaakceptowane'),
                 (STATUS_REJECTED, 'Odrzucone')]
 
+    BOOLEAN_CHOICES = [(True, "Tak"),
+                       (False, "Nie")]
+
     TYPES = [(TYPE_EXAM, 'Egzamin'),
              (TYPE_TEST, 'Kolokwium'),
              (TYPE_GENERIC, 'Wydarzenie'),
@@ -44,9 +47,7 @@ class Event(models.Model):
     description = models.TextField(verbose_name='Opis', blank=True)
     type = models.CharField(choices=TYPES, max_length=1, verbose_name='Typ')
     visible = models.BooleanField(verbose_name='Wydarzenie jest publiczne', default=False)
-
     status = models.CharField(choices=STATUSES, max_length=1, verbose_name='Stan', default='0')
-
     course = models.ForeignKey(CourseInstance, null=True, blank=True, on_delete=models.CASCADE)
     group = models.ForeignKey(Group, null=True, blank=True, on_delete=models.CASCADE)
     reservation = models.ForeignKey(

--- a/zapisy/apps/schedule/models/event.py
+++ b/zapisy/apps/schedule/models/event.py
@@ -28,9 +28,6 @@ class Event(models.Model):
                 (STATUS_ACCEPTED, 'Zaakceptowane'),
                 (STATUS_REJECTED, 'Odrzucone')]
 
-    BOOLEAN_CHOICES = [(True, "Tak"),
-                       (False, "Nie")]
-
     TYPES = [(TYPE_EXAM, 'Egzamin'),
              (TYPE_TEST, 'Kolokwium'),
              (TYPE_GENERIC, 'Wydarzenie'),

--- a/zapisy/apps/schedule/templates/schedule/includes/reservation_view.html
+++ b/zapisy/apps/schedule/templates/schedule/includes/reservation_view.html
@@ -8,8 +8,8 @@
                         {{ event.course.name }}
                     {% else %}
                         {{ event.title }}
+                    {% endif %}
                 </a>
-                {% endif %}
             </td>
         </tr>
         <tr>

--- a/zapisy/apps/schedule/templates/schedule/includes/reservation_view.html
+++ b/zapisy/apps/schedule/templates/schedule/includes/reservation_view.html
@@ -1,9 +1,15 @@
 <table class="table border">
     <tbody>
         <tr>
-            <th class="text-light bg-info"">Tytuł</th>
+            <th class="text-light bg-info">Tytuł</th>
             <td colspan="3">
-                {% if event.course %}<a href="">{{ event.course.name }}</a>{% else %}<a href="">{{ event.title }}</a>{% endif %}
+                <a href="{% url 'events:show' event.id %}">
+                    {% if event.course %}
+                        {{ event.course.name }}
+                    {% else %}
+                        {{ event.title }}
+                </a>
+                {% endif %}
             </td>
         </tr>
         <tr>
@@ -47,16 +53,6 @@
                     </tr>
                     {% endfor %}
                 </table>
-            </td>
-        </tr>
-        <tr>
-            <th class="text-light bg-info">Akcje</th>
-            <td colspan="3">
-                <div class="right">
-                    <span><a href="{% url 'events:show' event.id %}">
-                        <button class="btn btn-info">Zobacz</button>
-                    </a></span>
-                </div>
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION
W widoku https://zapisy.ii.uni.wroc.pl/events/history usunięto przyciski _Zobacz_, których funkcję pełnią teraz tytuły rezerwacji. Zlikwidowano podwójne opcje `----------` w filtrach _Typ_ oraz _Status_ i zastąpiono je poprzez opcję _Dowolny_. Przetłumaczono również opcje w dropdownie _Wydarzenie jest publiczne_.

Fixes #799 #800 