### PR TITLE
Poprawa błędu związanego z rezerwacją na wiele terminów

### DIFF
--- a/zapisy/apps/schedule/assets/reservation.js
+++ b/zapisy/apps/schedule/assets/reservation.js
@@ -12,7 +12,6 @@ var scroll = function(id) {
 
 // wyczyść formularz dodawania terminu
 var resetAddTermForm = function() {
-    $('#hiddenroom').val('');
     $('#inputplace').val('');
     $('#addterm').text('Dodaj termin');
 };


### PR DESCRIPTION
Do ukrytego pola z id hiddenroom zapisujemy unikatowe id sali, natomiast do pola tekstowego z id location jedynie napis "Sala " + jej numer. Czyszczenie ukrytego pola z id hiddenroom oraz pozostawianie w polu location nazwy sali powodowało, że można było dodać kolejny termin niezawierający prawdziwego id sali. W dalszej części skutkowało to rezerwacją sali tylko w pierwszym terminie, gdyż pozostałe nie posiadały id sali. Teraz po dodaniu terminu ukryte pole nie jest czyszczone, dzięki czemu możemy dodać wiele terminów, jednocześnie nie musząc zaznaczać sali za każdym razem.