### PR TITLE
Naprawa filtrowania rezerwacji

### DIFF
--- a/zapisy/apps/schedule/filters.py
+++ b/zapisy/apps/schedule/filters.py
@@ -8,6 +8,8 @@ BOOLEAN_CHOICES = [(True, "Tak"),
 
 
 class EventFilter(django_filters.FilterSet):
+    title = django_filters.CharFilter(field_name='title',
+                                      lookup_expr='icontains')
     type = django_filters.ChoiceFilter(choices=Event.TYPES,
                                        label='Typ',
                                        empty_label="Dowolny")


### PR DESCRIPTION
W polu Tytuł nie musimy teraz podawać pełnego tytułu wydarzenia. Możemy wpisać jego fragment, nie zważając na wielkość znaków.

Closes #814 