### PR TITLE
Druga pula poprawek w ocenie zajęć.

### DIFF
--- a/db_backups/anonymize.sql
+++ b/db_backups/anonymize.sql
@@ -15,5 +15,4 @@ DELETE FROM mailer_messagelog;
 UPDATE auth_user SET password='pbkdf2_sha256$36000$Z6GlerjZ9cWC$M6zn6XGPc81913R1yw6SMouredUfO/DPnQwZ3XxUCnA=';
 
 -- Anonymize grade/poll answers
-UPDATE poll_openquestionanswer SET content = 'jakas ocena';
-DELETE FROM poll_singlechoicequestionanswer;
+DELETE FROM poll_submission;

--- a/zapisy/apps/grade/poll/views.py
+++ b/zapisy/apps/grade/poll/views.py
@@ -11,11 +11,9 @@ from apps.grade.poll.forms import SubmissionEntryForm, TicketsEntryForm
 from apps.grade.poll.models import Poll, Submission
 from apps.grade.poll.utils import (
     PollSummarizedResults,
-    PollSummarizedResultsEntry,
     SubmissionWithStatus,
     check_grade_status,
     group,
-    group_submissions,
     group_submissions_with_statuses,
 )
 from apps.grade.ticket_create.models.rsa_keys import RSAKeys
@@ -187,7 +185,6 @@ class PollResults(TemplateView):
     @staticmethod
     def __get_counter_for_categories(polls):
         number_of_submissions_for_category = defaultdict(int)
-
         for poll in polls:
             if poll:
                 number_of_submissions_for_category[

--- a/zapisy/apps/grade/poll/views.py
+++ b/zapisy/apps/grade/poll/views.py
@@ -56,6 +56,8 @@ class TicketsEntry(TemplateView):
                     request, "Wprowadzone klucze nie są w poprawnym formacie."
                 )
                 return redirect('grade-poll-tickets-enter')
+            except ValueError as e:
+                messages.error(request, f"Niepoprawne klucze: {e}")
 
             entries = []
             for poll_with_ticket_id in correct_polls:

--- a/zapisy/apps/grade/poll/views.py
+++ b/zapisy/apps/grade/poll/views.py
@@ -56,6 +56,7 @@ class TicketsEntry(TemplateView):
                 return redirect('grade-poll-tickets-enter')
             except ValueError as e:
                 messages.error(request, f"Niepoprawne klucze: {e}")
+                return redirect('grade-poll-tickets-enter')
 
             entries = []
             for poll_with_ticket_id in correct_polls:

--- a/zapisy/apps/grade/poll/views.py
+++ b/zapisy/apps/grade/poll/views.py
@@ -287,7 +287,7 @@ class ClearSession(View):
     """Removes submissions from the active session."""
 
     def get(self, request):
-        del self.request.session['grade_poll_submissions']
+        self.request.session.flush()
         messages.success(
             request,
             "Dziękujemy za wzięcie udziału w ocenie zajęć! "

--- a/zapisy/apps/grade/ticket_create/models/rsa_keys.py
+++ b/zapisy/apps/grade/ticket_create/models/rsa_keys.py
@@ -37,7 +37,7 @@ class RSAKeys(models.Model):
         Raises:
             JSONDecodeError: when provided string is not in json format.
             ValueError: when there is something wrong with internal ticket format,
-                for example, some of the requred fields are not provided, type
+                for example, some of the required fields are not provided, type
                 of field is incorrect, there are duplicate ids, or id does not
                 exist in database.
         Returns:
@@ -50,9 +50,11 @@ class RSAKeys(models.Model):
         try:
             tickets_list = tickets['tickets']
             tickets_ids = [ticket['id'] for ticket in tickets_list]
-        except (KeyError, TypeError):
+        except KeyError as e:
             # If one of the keys wasn't there, it must have been an issue with the format.
-            raise JSONDecodeError
+            raise ValueError(f"W słowniku brakuje pola {e}")
+        except TypeError as e:
+            raise ValueError(f"{e}")
 
         # Make sure there are no duplicate ids
         if len(tickets_ids) != len(set(tickets_ids)):

--- a/zapisy/apps/grade/ticket_create/models/rsa_keys.py
+++ b/zapisy/apps/grade/ticket_create/models/rsa_keys.py
@@ -51,7 +51,7 @@ class RSAKeys(models.Model):
             tickets_list = tickets['tickets']
             tickets_ids = [ticket['id'] for ticket in tickets_list]
         except (KeyError, TypeError):
-            # If one of the keys wasn't there, it must have been an issue vith a format.
+            # If one of the keys wasn't there, it must have been an issue with the format.
             raise JSONDecodeError
 
         # Make sure there are no duplicate ids

--- a/zapisy/apps/grade/ticket_create/models/rsa_keys.py
+++ b/zapisy/apps/grade/ticket_create/models/rsa_keys.py
@@ -1,4 +1,5 @@
 import json
+from json.decoder import JSONDecodeError
 from django.db import models
 from Crypto.PublicKey import RSA
 from Crypto.Hash import SHA256
@@ -46,9 +47,12 @@ class RSAKeys(models.Model):
             track which ticket has already been used to vote.
         """
         tickets = json.loads(raw_tickets)
-        tickets_list = tickets['tickets']
-
-        tickets_ids = [ticket['id'] for ticket in tickets_list]
+        try:
+            tickets_list = tickets['tickets']
+            tickets_ids = [ticket['id'] for ticket in tickets_list]
+        except (KeyError, TypeError):
+            # If one of the keys wasn't there, it must have been an issue vith a format.
+            raise JSONDecodeError
 
         # Make sure there are no duplicate ids
         if len(tickets_ids) != len(set(tickets_ids)):

--- a/zapisy/apps/grade/ticket_create/models/rsa_keys.py
+++ b/zapisy/apps/grade/ticket_create/models/rsa_keys.py
@@ -1,9 +1,7 @@
 import json
-from json.decoder import JSONDecodeError
 from django.db import models
 from Crypto.PublicKey import RSA
 from Crypto.Hash import SHA256
-from Crypto.Signature import PKCS1_v1_5
 from apps.grade.poll.models import Poll
 
 


### PR DESCRIPTION
Nowa ocena zajęć przeżywa pewne choroby wieku dziecięcego. Oto druga pula poprawek. Zawiera się w niej:

1. Sprawniejsze liczenie odpowiedzi na ankiety. Robimy to teraz stałą liczbą zapytań, a nie liniową.
2. Naprawienie błędu polegającego na niewyświetlaniu właścicielowi przedmiotu ankiet dotyczących grup tego przedmiotu (@j-michaliszyn).
3. Naprawienie anonimizacji back-upów.
4. Usunięcie niepotrzebnych funkcji z modelu `Submission`.
5. Bardziej uważne wychwytywanie błędów przy parsowaniu wklejanych przez studentów biletów.

Fixes #834
Fixes #835