### PR TITLE
Udogodnienia widoku statystyk

### DIFF
--- a/zapisy/apps/enrollment/courses/templates/courses/course_info.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_info.html
@@ -3,7 +3,7 @@
 {% regroup groups|dictsort:"type" by type as groups_by_type %}
 
 {% for class_type, class_groups in groups_by_type %}
-    {% include "courses/course_parts/groups_section.html" with class_type=class_type class_groups=class_groups %}
+    {% include "courses/course_parts/groups_section.html" with class_type=class_type class_groups=class_groups waiting_students=waiting_students %}
 {% endfor %}
 
 <hr>

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -84,15 +84,6 @@
             </td>
         </tr>
         {% endif %}
-        {% for group_of_waiting_students in grouped_waiting_students %}
-            {# This will only be non-empty when the requesting user is staff #}
-            {% if group_of_waiting_students.students_amount %}
-                <tr>
-                    <th scope="row">Liczba chętnych na {{ group_of_waiting_students.type_name }}</th>
-                    <td>{{ group_of_waiting_students.students_amount }}</td>
-                </tr>
-            {% endif %}
-        {% endfor %}
     </tbody>
 </table>
 

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/groups_section.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/groups_section.html
@@ -1,4 +1,5 @@
 {% load course_types %}
+{% load filters %}
 
 <div class="table-responsive tutorial">
     <h3>{{ class_type|decode_class_type_plural  }}</h3>
@@ -103,4 +104,20 @@
         <p><strong>UWAGA!</strong>
             Wyższa liczba oznacza wyższy priorytet, po zapisaniu do grupy zostajemy usunięci z kolejek o niższym priorytecie.
         </p>
+        {% if class_type in waiting_students %}
+            <p>Niezapisani studenci w kolejkach na {{ class_type|decode_class_type_plural }}
+                ({{ waiting_students|lookup:class_type|length }}):
+                <a data-toggle="collapse" href="#waiting-{{class_type}}-collapse" 
+                    role="button" aria-expanded="false" aria-controls="collapseExample">
+                    zwiń / rozwiń
+                </a>
+            </p>
+            <div class="collapse" id="waiting-{{class_type}}-collapse">
+                <ul>
+                    {% for st_id, st_fn, st_ln in waiting_students|lookup:class_type %}
+                        <li><a href="{% url 'student-profile' st_id %}">{{ st_fn }} {{ st_ln }}</a></li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
     </div>

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/groups_section.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/groups_section.html
@@ -2,7 +2,14 @@
 {% load filters %}
 
 <div class="table-responsive tutorial">
-    <h3>{{ class_type|decode_class_type_plural  }}</h3>
+    <h3 class="d-inline-block">{{ class_type|decode_class_type_plural  }} 
+    </h3>
+    {% if class_type in waiting_students %}
+        <span class="badge badge-danger d-inline-block align-text-bottom ml-2">
+            Niezapisanych&mdash;oczekujących
+            <span class="badge badge-light">{{ waiting_students|lookup:class_type }}</span>
+        </span>
+    {% endif %}
     <table class="table table-bordered text-center">
         <thead class="thead-dark">
             <tr>
@@ -104,20 +111,4 @@
         <p><strong>UWAGA!</strong>
             Wyższa liczba oznacza wyższy priorytet, po zapisaniu do grupy zostajemy usunięci z kolejek o niższym priorytecie.
         </p>
-        {% if class_type in waiting_students %}
-            <p>Niezapisani studenci w kolejkach na {{ class_type|decode_class_type_plural }}
-                ({{ waiting_students|lookup:class_type|length }}):
-                <a data-toggle="collapse" href="#waiting-{{class_type}}-collapse" 
-                    role="button" aria-expanded="false" aria-controls="collapseExample">
-                    zwiń / rozwiń
-                </a>
-            </p>
-            <div class="collapse" id="waiting-{{class_type}}-collapse">
-                <ul>
-                    {% for st_id, st_fn, st_ln in waiting_students|lookup:class_type %}
-                        <li><a href="{% url 'student-profile' st_id %}">{{ st_fn }} {{ st_ln }}</a></li>
-                    {% endfor %}
-                </ul>
-            </div>
-        {% endif %}
     </div>

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -91,11 +91,18 @@ def course_view_data(request, slug) -> Tuple[Optional[CourseInstance], Optional[
 
     course.is_enrollment_on = any(g.can_enqueue for g in groups)
 
+    waiting_students = {}
+    if BaseUser.is_employee(request.user):
+        waiting_students = {
+            t: sts
+            for ((_, t), sts) in Record.list_waiting_students([course]).items()
+        }
+
     data = {
         'course': course,
         'teachers': teachers,
         'groups': groups,
-        'grouped_waiting_students': get_grouped_waiting_students(course, request.user)
+        'waiting_students': waiting_students,
     }
     return course, data
 
@@ -213,23 +220,3 @@ def group_queue_csv(request, group_id):
     except Group.DoesNotExist:
         raise Http404
     return recorded_students_csv(group_id, RecordStatus.QUEUED)
-
-
-def get_grouped_waiting_students(course: CourseInstance, user) -> List:
-    """Return numbers of waiting students grouped by course group type.
-
-    The user argument is used to decide if the list should be generated at all.
-    """
-    if not user.is_superuser:
-        return []
-
-    group_types: List = [
-        {'id': '2', 'name': 'cwiczenia'},
-        {'id': '3', 'name': 'pracownie'},
-        {'id': '5', 'name': 'ćwiczenio-pracownie'}
-    ]
-
-    return [{
-        'students_amount': Record.get_number_of_waiting_students(course, group_type['id']),
-        'type_name': group_type['name']
-    } for group_type in group_types]

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -93,10 +93,7 @@ def course_view_data(request, slug) -> Tuple[Optional[CourseInstance], Optional[
 
     waiting_students = {}
     if BaseUser.is_employee(request.user):
-        waiting_students = {
-            t: sts
-            for ((_, t), sts) in Record.list_waiting_students([course]).items()
-        }
+        waiting_students = Record.list_waiting_students([course])[course.id]
 
     data = {
         'course': course,

--- a/zapisy/apps/enrollment/records/models/records.py
+++ b/zapisy/apps/enrollment/records/models/records.py
@@ -42,9 +42,10 @@ Record Lifetime:
     filled by an asynchronous process, so the GROUP_CHANGE_SIGNAL is sent.
 """
 
+from collections import defaultdict
 import logging
 from datetime import datetime
-from typing import Dict, Iterable, List, Optional, Set
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 from choicesenum import ChoicesEnum
 from enum import Enum
@@ -215,18 +216,34 @@ class Record(models.Model):
         return {k.id: True for k in groups}
 
     @staticmethod
-    def get_number_of_waiting_students(course: CourseInstance, group_type: str) -> int:
-        """Returns number of students waiting to be enrolled.
+    def list_waiting_students(
+            courses: List[CourseInstance]) -> Dict[Tuple[int, int], List[Tuple[int, str, str]]]:
+        """Returns students waiting to be enrolled.
 
         Returned students aren't enrolled in any group of given type within
         given course, but they are enqueued into at least one.
+
+        Returns:
+          A dict mapping a pair (course_id, group_type) to a tuple (student_id,
+          first_name, last_name) representing a student.
         """
-        return Record.objects.filter(
-            status=RecordStatus.QUEUED, group__course=course,
-            group__type=group_type).only('student').exclude(
-                student__in=Record.objects.filter(
-                    status=RecordStatus.ENROLLED, group__course=course, group__type=group_type).
-                only('student').values_list('student')).distinct('student').count()
+        queued = Record.objects.filter(
+            status=RecordStatus.QUEUED, group__course__in=courses).values(
+                'group__course', 'group__type', 'student__user',
+                'student__user__first_name', 'student__user__last_name')
+        enrolled = Record.objects.filter(
+            status=RecordStatus.ENROLLED, group__course__in=courses).values(
+                'group__course', 'group__type', 'student__user', 'student__user__first_name',
+                'student__user__last_name')
+        waiting = queued.difference(enrolled)
+        ret = defaultdict(list)
+        for w in waiting:
+            ret[(w['group__course'], w['group__type'])].append((
+                w['student__user'],
+                w['student__user__first_name'],
+                w['student__user__last_name'],
+            ))
+        return ret
 
     @classmethod
     def is_enrolled(cls, student: Student, group: Group) -> bool:

--- a/zapisy/apps/enrollment/records/tests/test_enrollment.py
+++ b/zapisy/apps/enrollment/records/tests/test_enrollment.py
@@ -336,9 +336,9 @@ class EnrollmentTest(TestCase):
             Record.enqueue_student(self.lolek, self.cooking_exercise_group_1)
 
             expected_waiting = {
-                (self.cooking_exercise_group_1.course_id, self.cooking_exercise_group_1.type): [
-                    (self.tola.user_id, self.tola.user.first_name, self.tola.user.last_name)
-                ]
+                self.cooking_exercise_group_1.course_id: {
+                    self.cooking_exercise_group_1.type: 1
+                }
             }
             self.assertDictEqual(
                 Record.list_waiting_students([self.cooking_exercise_group_1.course]),

--- a/zapisy/apps/enrollment/records/tests/test_enrollment.py
+++ b/zapisy/apps/enrollment/records/tests/test_enrollment.py
@@ -335,6 +335,11 @@ class EnrollmentTest(TestCase):
             Record.enqueue_student(self.bolek, self.cooking_exercise_group_2)
             Record.enqueue_student(self.lolek, self.cooking_exercise_group_1)
 
-            self.assertEqual(
-                Record.get_number_of_waiting_students(
-                    self.cooking_exercise_group_1.course, group_type=2), 1)
+            expected_waiting = {
+                (self.cooking_exercise_group_1.course_id, self.cooking_exercise_group_1.type): [
+                    (self.tola.user_id, self.tola.user.first_name, self.tola.user.last_name)
+                ]
+            }
+            self.assertDictEqual(
+                Record.list_waiting_students([self.cooking_exercise_group_1.course]),
+                expected_waiting)

--- a/zapisy/apps/statistics/templates/statistics/groups_list.html
+++ b/zapisy/apps/statistics/templates/statistics/groups_list.html
@@ -16,7 +16,7 @@
                 <th scope="col">Zapisani</th>
                 <th scope="col">Kolejka</th>
                 <th scope="col">Przypięci</th>
-
+                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -28,10 +28,25 @@
                     <tr>
                         <td>{{ group.teacher }}</td>
                         <td>{{ group.get_type_display }}</td>
-                        <td>{{ group.limit }}</td>
+                        <td>
+                            {{ group.limit }}
+                            {% for gs in group.guaranteed_spots.all %}
+                                + 
+                                <span title="Miejsca gwarantowane dla grupy {{gs.role.name}}.">
+                                    {{ gs.limit }}
+                                </span>
+                            {% endfor %}
+                        </td>
                         <td>{{ group.enrolled }}</td>
                         <td>{{ group.queued }}</td>
                         <td>{{ group.pinned }}</td>
+                        <td>
+                            <a class="badge badge-sm badge-primary"
+                                href="{% url 'admin:courses_group_change' group.id %}"
+                                target="_blank">
+                                Admin <i class="fas fas-sm fa-external-link-alt"></i>
+                            </a>
+                        </td>
                     </tr>
                 {% endfor %}
             {% endfor %}

--- a/zapisy/apps/statistics/templates/statistics/groups_list.html
+++ b/zapisy/apps/statistics/templates/statistics/groups_list.html
@@ -1,5 +1,8 @@
 {% extends "statistics/base.html" %}
 
+{% load filters %}
+{% load course_types %}
+
 {% block statistics-groups-active %}active{% endblock %}
 
 {% block statistics-content %}
@@ -19,10 +22,24 @@
                 <th></th>
             </tr>
         </thead>
-        <tbody>
-            {% for course, groups in courses_list %}
+        {% for course, groups in courses_list %}
+            <tbody>
                 <tr>
-                    <th colspan="12">{{ course.name }}</th>
+                    <th colspan="2">
+                        {{ course.name }}
+                    </th>
+                    <td colspan="6">
+                        {% with waiting_course=waiting_students|lookup:course.id %}
+                            {% for course_type in waiting_course %}
+                                <span class="badge badge-danger" title="Oczekujących w kolejkach">
+                                    {{ course_type|decode_class_type_plural }}
+                                    <span class="badge badge-light">
+                                        {{ waiting_course|lookup:course_type|length }}
+                                    </span>
+                                </span>
+                            {% endfor %}
+                        {% endwith %}
+                    </td>
                 </tr>
                 {% for group in groups %}
                     <tr>
@@ -49,8 +66,8 @@
                         </td>
                     </tr>
                 {% endfor %}
-            {% endfor %}
-        </tbody>
+            </tbody>
+        {% endfor %}
     </table>
 </div>
 {% endblock %}

--- a/zapisy/apps/statistics/templates/statistics/groups_list.html
+++ b/zapisy/apps/statistics/templates/statistics/groups_list.html
@@ -34,7 +34,7 @@
                                 <span class="badge badge-danger" title="Oczekujących w kolejkach">
                                     {{ course_type|decode_class_type_plural }}
                                     <span class="badge badge-light">
-                                        {{ waiting_course|lookup:course_type|length }}
+                                        {{ waiting_course|lookup:course_type }}
                                     </span>
                                 </span>
                             {% endfor %}

--- a/zapisy/apps/statistics/templates/statistics/groups_list.html
+++ b/zapisy/apps/statistics/templates/statistics/groups_list.html
@@ -22,8 +22,8 @@
                 <th></th>
             </tr>
         </thead>
-        {% for course, groups in courses_list %}
-            <tbody>
+        <tbody>
+            {% for course, groups in courses_list %}
                 <tr>
                     <th colspan="2">
                         {{ course.name }}
@@ -66,8 +66,8 @@
                         </td>
                     </tr>
                 {% endfor %}
-            </tbody>
-        {% endfor %}
+            {% endfor %}
+        </tbody>
     </table>
 </div>
 {% endblock %}

--- a/zapisy/apps/statistics/views.py
+++ b/zapisy/apps/statistics/views.py
@@ -1,3 +1,5 @@
+from apps.enrollment.courses.models.course_instance import CourseInstance
+from apps.enrollment.records.models.records import Record
 from django.contrib.auth.decorators import permission_required
 from django.db import models
 from django.shortcuts import render
@@ -37,6 +39,9 @@ def groups(request):
             'course__name', 'teacher__user__first_name', 'teacher__user__last_name', 'limit',
             'type').prefetch_related('guaranteed_spots', 'guaranteed_spots__role').annotate(
                 enrolled=enrolled_agg).annotate(queued=queued_agg).annotate(pinned=pinned_agg)
+    waiting_students = Record.list_waiting_students(
+        CourseInstance.objects.filter(semester=semester))
     return render(request, 'statistics/groups_list.html', {
         'groups': groups,
+        'waiting_students': waiting_students,
     })

--- a/zapisy/apps/statistics/views.py
+++ b/zapisy/apps/statistics/views.py
@@ -35,8 +35,8 @@ def groups(request):
     groups = Group.objects.filter(course__semester=semester).select_related(
         'course', 'teacher', 'teacher__user').order_by('course', 'type').only(
             'course__name', 'teacher__user__first_name', 'teacher__user__last_name', 'limit',
-            'type').annotate(enrolled=enrolled_agg).annotate(queued=queued_agg).annotate(
-                pinned=pinned_agg)
+            'type').prefetch_related('guaranteed_spots', 'guaranteed_spots__role').annotate(
+                enrolled=enrolled_agg).annotate(queued=queued_agg).annotate(pinned=pinned_agg)
     return render(request, 'statistics/groups_list.html', {
         'groups': groups,
     })


### PR DESCRIPTION
Zmiana ta skupia się na widoku statystyk grup. 
- W każdym odpowiadającym grupie wierszu umieszczamy link do jej panelu admina.
- Wyświetlamy liczby miejsc gwarantowanych w każdej grupie.
- Wyświetlamy liczbę oczekujących do typów grup każdego przedmiotu.