### PR TITLE
Poprawki do nakładki na API

### DIFF
--- a/zapisy/apps/api/rest/v1/api_wrapper/sz_api/models.py
+++ b/zapisy/apps/api/rest/v1/api_wrapper/sz_api/models.py
@@ -20,8 +20,6 @@ class Model:
         """Converts model to dict recursively"""
         data = {}
         for key, value in self.__dict__.items():
-            if value is None:
-                continue
             try:
                 data[key] = value.to_dict()
             except AttributeError:

--- a/zapisy/apps/api/rest/v1/api_wrapper/sz_api/sz_api.py
+++ b/zapisy/apps/api/rest/v1/api_wrapper/sz_api/sz_api.py
@@ -45,7 +45,10 @@ class ZapisyApi:
         self.redirect_map = self._get_redirect_map(api_url)
 
     def _get_redirect_map(self, api_url: str) -> dict:
-        return self._handle_get_request(api_url)
+        rm = self._handle_get_request(api_url)
+        for key in rm:
+            rm[key] = rm[key].replace('http:', 'https:', 1)
+        return rm
 
     def save(self, obj: Model):
         self._handle_patch_request(
@@ -280,7 +283,7 @@ class ZapisyApi:
             return None
 
     def _handle_patch_request(self, path, data: dict):
-        self._handle_upload_request("patch", path, data)
+        return self._handle_upload_request("patch", path, data)
 
     def _handle_post_request(self, path, data: dict):
         return self._handle_upload_request("post", path, data)
@@ -303,10 +306,6 @@ class ZapisyApi:
             # DRF requires trailing slash for patch method
             path if path.endswith("/") else path + "/",
             json=data,
-            headers={"Authorization": self.token}
-        )
+            headers={"Authorization": self.token})
         resp.raise_for_status()
-        try:
-            return resp.json()['id']
-        except json.decoder.JSONDecodeError:
-            return None
+        return resp

--- a/zapisy/apps/api/rest/v1/api_wrapper/sz_api/sz_api.py
+++ b/zapisy/apps/api/rest/v1/api_wrapper/sz_api/sz_api.py
@@ -1,6 +1,6 @@
 import json
 import requests
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from typing import Iterator, Optional
 
 from .models import (User, Program,
@@ -46,8 +46,11 @@ class ZapisyApi:
 
     def _get_redirect_map(self, api_url: str) -> dict:
         rm = self._handle_get_request(api_url)
+        base_url_parts = urlparse(api_url)
         for key in rm:
-            rm[key] = rm[key].replace('http:', 'https:', 1)
+            route_url_parts = urlparse(rm[key])
+            modified_url_parts = route_url_parts._replace(scheme=base_url_parts.scheme)
+            rm[key] = modified_url_parts.geturl()
         return rm
 
     def save(self, obj: Model):

--- a/zapisy/apps/api/rest/v1/api_wrapper/sz_api/sz_api.py
+++ b/zapisy/apps/api/rest/v1/api_wrapper/sz_api/sz_api.py
@@ -224,8 +224,9 @@ class ZapisyApi:
             User(None, str(indeks), first_name, last_name, email),
             Program(None, program_name), semestr, algorytmy_l,
             numeryczna_l, dyskretna_l)
-        return self._handle_post_request(
+        resp = self._handle_post_request(
             self.redirect_map[Student.redirect_key], student.to_dict())
+        return resp.json()['id']
 
     def _get_deserialized_data(self, model_class, params=None):
         if model_class.is_paginated:

--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -86,7 +86,7 @@ class ProgramSerializer(serializers.ModelSerializer):
 
 class StudentSerializer(serializers.ModelSerializer):
     user = UserSerializer()
-    program = ProgramSerializer()
+    program = ProgramSerializer(required=False, allow_null=True)
 
     class Meta:
         model = Student
@@ -115,6 +115,8 @@ class StudentSerializer(serializers.ModelSerializer):
         program_data = validated_data.pop('program', None)
         if program_data is not None:
             instance.program = Program.objects.get(name=program_data['name'])
+        else:
+            instance.program = None
         return super().update(instance, validated_data)
 
 


### PR DESCRIPTION
Wprowadza małe poprawki do biblioteki obsługującej API Systemu Zapisów.

1. Naprawia zapisywanie. Nie działało ono z dość skomplikowanego powodu. Strona https://zapisy.ii.uni.wroc.pl/api/v1/ pokazuje ścieżki z protokołem `http://`. Gdy wysyłamy zapytanie przez taką ścieżkę, serwer Nginx przekierowuje zapytanie na `https://` ale gubi nagłówek `Content-Type: application/json`. Serwer nie interpretuje zapytania poprawnie bez tego nagłówka. By rozwiązać ten problem podmieniamy `http:` na `https:` w ścieżkach.
2. Wrapper usuwał klucze z wartościami `None` z zapytania. Przez to nie dało się wyzerować jakiejś wartości. Zmieniamy to.