### PR TITLE
Linki do przedmiotów na stronie z egzaminami

### DIFF
--- a/zapisy/apps/schedule/templates/schedule/session.html
+++ b/zapisy/apps/schedule/templates/schedule/session.html
@@ -27,7 +27,7 @@
             {% regroup exam.list|dictsort:"event.course.name" by event.course as list %}
             {% for ll in list %}
                 <dd>
-                    <h6><a href="{{ ll.grouper.get_absolute_url }}">{{ ll.grouper.name }}</a></h6>
+                    <h6><a href="{% url 'course-page' ll.grouper.slug %}">{{ ll.grouper.name }}</a></h6>
                     <ul>
                         {% for term in ll.list %}
                             <li>


### PR DESCRIPTION
PR naprawia linki do stron przedmiotów w danym semestrze, na stronie z egzaminami.

Fixed #811 