### PR TITLE
Zwijalny pasek boczny

### DIFF
--- a/zapisy/asset-defs.ts
+++ b/zapisy/asset-defs.ts
@@ -9,6 +9,7 @@ export default {
             "common/index.scss",
             "common/cookieconsent/display-cookieconsent.ts",
             "common/icons-library.ts",
+            "common/sidebar-fold.js",
         ],
         "render-markdown": [
             "common/render-markdown.ts",

--- a/zapisy/assets/common/index.scss
+++ b/zapisy/assets/common/index.scss
@@ -87,9 +87,7 @@ div.top .topbar .inline-inputs label {
   @media (max-width: 992px) {
     #sidebar-inner {
       overflow-y: hidden;
-      max-height: 100%;
-      transition: all .5s linear 0s;
-    
+
       &.folded {
         max-height: 200px;
 

--- a/zapisy/assets/common/index.scss
+++ b/zapisy/assets/common/index.scss
@@ -83,6 +83,47 @@ div.top .topbar .inline-inputs label {
   }
 }
 
+#sidebar {
+  @media (max-width: 992px) {
+    #sidebar-inner {
+      overflow-y: hidden;
+      max-height: 100%;
+      transition: all .5s linear 0s;
+    
+      &.folded {
+        max-height: 200px;
+
+        // Blurs over the bottom of filter card.
+        &:after {
+          position: absolute;
+          display: block;
+          // Height of the card footer.
+          bottom: 1.5em;
+          left: 0;
+          height: 50%;
+          width: 100%;
+          content: "";
+          // Bootstrap light colour.
+          background: linear-gradient(to top,
+              rgba(255,255,255, 1) 0%, 
+              rgba(255,255,255, 0) 100%
+          );
+          pointer-events: none; /* so the text is still selectable */
+        }
+      }
+    }
+    #fold-toggler {
+      display: block;
+      text-align: center;
+    }
+  }
+  @media (min-width: 992px) {
+    #fold-toggler {
+      display: none;
+    }
+  }
+}
+
 div.loginbox {
   background-color: #f5f5f5;
   -webkit-border-radius: 6px;

--- a/zapisy/assets/common/sidebar-fold.js
+++ b/zapisy/assets/common/sidebar-fold.js
@@ -1,0 +1,15 @@
+// Implements folding sidebar contents on small devices.
+
+function toggleSidebarFolded(event) {
+    const sidebarInner = document.getElementById("sidebar-inner");
+    sidebarInner.classList.toggle("folded");
+    event.preventDefault();
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+    const sidebarFoldButton = document.getElementById("fold-toggler");
+    if (!sidebarFoldButton) {
+        return;
+    }
+    sidebarFoldButton.addEventListener("click", toggleSidebarFolded);
+});

--- a/zapisy/templates/base.html
+++ b/zapisy/templates/base.html
@@ -208,7 +208,7 @@
                         {% block sidebar %}
                         {% endblock %}
                     </div>
-                    <a href="#" id="fold-toggler">zwiń / rozwiń</a>
+                    <a class="text-dark" href="#" id="fold-toggler">zwiń / rozwiń</a>
                 </nav>
             </div>
             {% endblock %}

--- a/zapisy/templates/base.html
+++ b/zapisy/templates/base.html
@@ -197,14 +197,18 @@
                 </div>
             </div>
             <div class="row my-4">
-                <div class="col-lg-9 col-12" id="main-content">
-                    {# WARNING ajaxCourseLoad.ts depends on this #}
-                        {% block content %}
-                        {% endblock %}
-                </div>
-                <nav class="col-lg-3 col-12 d-print-none" id="sidebar">
-                    {% block sidebar %}
+                <div class="col-lg-9 col-12 order-last order-lg-first" id="main-content">
+                    {% block content %}
                     {% endblock %}
+                </div>
+                <nav class="col-lg-3 col-12
+                        d-print-none order-first
+                        order-lg-last mb-3" id="sidebar">
+                    <div class="folded" id="sidebar-inner">
+                        {% block sidebar %}
+                        {% endblock %}
+                    </div>
+                    <a href="#" id="fold-toggler">zwiń / rozwiń</a>
                 </nav>
             </div>
             {% endblock %}


### PR DESCRIPTION
Od jakiegoś czasu szukamy dobrego pomysłu na wyświetlanie na urządzeniach mobilnych paska bocznego (_sidebar_). Zazwyczaj są na nim wyświetlane listy: przedmiotów, propozycji, pracowników, studentów, sal.

Jednym pomysłem było, by pasek znikał za prawą krawędzią ekranu. Byłby przywoływany gestem. Nie byłby on może niedorzeczny, gdyby to dobrze zrealizować, ale nie wiem, jak zadbać o to, by było jasne, że ten pasek tam się kryje. Być może jakiś ekspert od UI kiedyś nam pomoże.

Na razie proponujemy inne rozwiązanie: na urządzeniach mobilnych pasek jest widoczny, ale tylko do określonej, niedużej wysokości, a dalej ucięty. W ten sposób nie trzeba długo przewijać, by dostać się do właściwej treści (np. strony przedmiotu albo planu zajęć pracownika). Ucięcie jest zamglone, żeby było jasne, że można go rozwinąć i zobaczyć więcej treści. Podobnego tricku użyliśmy wcześniej w filtrze przedmiotów.


| Pasek zwinięty                  | Pasek rozwinięty                      |
| ---------------------------------- | ---------------------------------------- |
| ![0 0 0 0_8000_courses_algorytmy-kwantowe-q2-201920-letni(iPhone 6_7_8)](https://user-images.githubusercontent.com/5896456/79562195-ef8cd000-80aa-11ea-981c-d1e8ce83b27b.png) | ![0 0 0 0_8000_courses_algorytmy-kwantowe-q2-201920-letni(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/5896456/79562251-0b907180-80ab-11ea-9574-1517525939aa.png) |

Closes #751 