### PR TITLE
Filtr powinien brać przekrój a nie sumę zbiorów.

### DIFF
--- a/zapisy/apps/users/assets/components/UserList.vue
+++ b/zapisy/apps/users/assets/components/UserList.vue
@@ -52,8 +52,8 @@ export default {
                         "album",
                     ];
             const values = map(props, (p) => get(user, p, "").toLowerCase());
-            const anyPropMatches = (word) => !some(values, (v) => v.includes(word));
-            return !every(words, anyPropMatches);
+            const anyPropMatches = (word) => some(values, (v) => v.includes(word));
+            return every(words, anyPropMatches);
         },
         matchChar: function (user) {
             let last_name = user.last_name.toLowerCase();


### PR DESCRIPTION
Filtr użytkowników powinien traktować kolejne wpisywane słowa jako
_uściślenie_, a nie _poszerzenie_ wyszukiwania, a więc wynik
wyszukiwania powinien być przekrojem wyników dla pojedynczych słów, a
nie sumą.