### PR TITLE
Limit grupy zajęciowej nie będzie aktualizowany na podstawie danych schedulera

### DIFF
--- a/zapisy/apps/schedulersync/management/commands/import_schedule.py
+++ b/zapisy/apps/schedulersync/management/commands/import_schedule.py
@@ -137,7 +137,7 @@ class Command(BaseCommand):
                 return diffs
 
             diffs.extend(prop_updater(term, term_data, ['dayOfWeek', 'start_time', 'end_time']))
-            diffs.extend(prop_updater(term.group, term_data, ['teacher', 'limit']))
+            diffs.extend(prop_updater(term.group, term_data, ['teacher']))
 
             if set(term.classrooms.all()) != term_data.classrooms:
                 diffs.append(SlackUpdate('classrooms', term.classrooms.all(), term_data.classrooms))

--- a/zapisy/apps/schedulersync/management/commands/import_schedule.py
+++ b/zapisy/apps/schedulersync/management/commands/import_schedule.py
@@ -136,6 +136,11 @@ class Command(BaseCommand):
                         setattr(a, prop, sched_val)
                 return diffs
 
+            # The class times and location will be managed in Scheduler, which
+            # is better at managing these. They should be synchronised down to
+            # the enrolment system.
+            # The group limit will be managed inside the system, so it should
+            # not be overwriten by the scheduler.
             diffs.extend(prop_updater(term, term_data, ['dayOfWeek', 'start_time', 'end_time']))
             # We _DO_NOT_ synchronize limit, see: pull request #891.
             diffs.extend(prop_updater(term.group, term_data, ['teacher']))

--- a/zapisy/apps/schedulersync/management/commands/import_schedule.py
+++ b/zapisy/apps/schedulersync/management/commands/import_schedule.py
@@ -137,6 +137,7 @@ class Command(BaseCommand):
                 return diffs
 
             diffs.extend(prop_updater(term, term_data, ['dayOfWeek', 'start_time', 'end_time']))
+            # We _DO_NOT_ synchronize limit, see: pull request #891.
             diffs.extend(prop_updater(term.group, term_data, ['teacher']))
 
             if set(term.classrooms.all()) != term_data.classrooms:

--- a/zapisy/apps/schedulersync/management/commands/import_schedule.py
+++ b/zapisy/apps/schedulersync/management/commands/import_schedule.py
@@ -140,7 +140,7 @@ class Command(BaseCommand):
             # is better at managing these. They should be synchronised down to
             # the enrolment system.
             # The group limit will be managed inside the system, so it should
-            # not be overwriten by the scheduler.
+            # not be overwritten by the scheduler.
             diffs.extend(prop_updater(term, term_data, ['dayOfWeek', 'start_time', 'end_time']))
             diffs.extend(prop_updater(term.group, term_data, ['teacher']))
 

--- a/zapisy/apps/schedulersync/management/commands/import_schedule.py
+++ b/zapisy/apps/schedulersync/management/commands/import_schedule.py
@@ -142,7 +142,6 @@ class Command(BaseCommand):
             # The group limit will be managed inside the system, so it should
             # not be overwriten by the scheduler.
             diffs.extend(prop_updater(term, term_data, ['dayOfWeek', 'start_time', 'end_time']))
-            # We _DO_NOT_ synchronize limit, see: pull request #891.
             diffs.extend(prop_updater(term.group, term_data, ['teacher']))
 
             if set(term.classrooms.all()) != term_data.classrooms:


### PR DESCRIPTION
Stosunkowo niedawno napisany od nowa skrypt do synchronizacji ze schedulerem wprowadził zmianę wobec wcześniejszego zachowania, tj. zaczął pobierać limit miejsc w grupie ze schedulera. Ze względu na zdarzające się programistyczne ingerencje w limity (np. podczas likwidacji miejsc gwarantowanych) nowe zachowanie nie znalazło zrozumienia u administratora. Ta poprawka przywraca stare zachowanie, w którym to zawartość bazy danych stanowi źródło prawdy dla limitu miejsc w grupie.

Grupy nieistniejące w systemie zapisów zostają jednak pobrane ze Schedulera z limitem (co jest zmianą w stosunku do poprzedniego skryptu, który całkowicie ignorował ten limit).