### PR TITLE
Wyłącza sprawdzanie url-i od serwera CAS.

### DIFF
--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -268,7 +268,7 @@ CAS_REDIRECT_URL = LOGOUT_REDIRECT_URL
 
 # This chceck has to be disabled as long as we are using an incorrect Nginx
 # configuration which rewrites HTTPS to HTTP.
-CAS_CHECK_NEXT = lambda _: True
+CAS_CHECK_NEXT = lambda _: True  # noqa: E731
 
 LOGIN_REDIRECT_URL = '/users/'
 

--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -266,6 +266,10 @@ CAS_LOGOUT_COMPLETELY = False
 LOGOUT_REDIRECT_URL = '/'
 CAS_REDIRECT_URL = LOGOUT_REDIRECT_URL
 
+# This chceck has to be disabled as long as we are using an incorrect Nginx
+# configuration which rewrites HTTPS to HTTP.
+CAS_CHECK_NEXT = lambda _: True
+
 LOGIN_REDIRECT_URL = '/users/'
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'


### PR DESCRIPTION
Sprawdzenie to nie przechodzi ze względu na niepoprawną konfigurację
naszego serwera Nginx.

Resolves #898