### PR TITLE
Zawsze migruj bazę przy provisioningu.

### DIFF
--- a/ansible/postgres.yml
+++ b/ansible/postgres.yml
@@ -88,5 +88,4 @@
         command: migrate
         app_path: "/vagrant/zapisy"
         virtualenv: "/home/vagrant/env3"
-      when: not dumpsql.stat.exists
 


### PR DESCRIPTION
Gdy robimy `vagrant provision` (albo pierwsze `vagrant up`), z pliku ładowany jest obraz bazy danych. Z jakiegoś powodu, nie są uruchamiane wtedy migracje, co skutkuje nie działąjącym systemem, gdy pracujemy na branchu wprowadzającym zmiany w schemacie bazy danych.