### PR TITLE
Usuwa klasę social-buttons z logowania przez CAS.

### DIFF
--- a/zapisy/templates/base.html
+++ b/zapisy/templates/base.html
@@ -101,7 +101,7 @@
                             <b>Zaloguj się</b><span class="caret"></span>
                         </a>
                         <div class="dropdown-menu dropdown-menu-right m-2">
-                            <div class="social-buttons m-3">
+                            <div class="m-3">
                                 <a href="{% url 'cas_ng_login' %}" class="btn btn-primary">
                                     <img src="{% static 'images/logo-uwr.svg' %}"
                                          alt="Uniwersytet Wrocławski">


### PR DESCRIPTION
Link do logowania przez uniwersytecki serwer CAS ma HTML-ową klasę
`social-buttons`. Klasa ta jest filtrowana przez opcjonalne filtry Adblocka, a przez nas
zupełnie nieużywana. Dlatego można ją usunąć.


|       Przed        |            Po         |
| ------------------- | ------------------- |
| ![image](https://user-images.githubusercontent.com/5896456/84124414-7c189680-aa3b-11ea-98ae-872e3d3f3315.png) | ![image](https://user-images.githubusercontent.com/5896456/84124481-93f01a80-aa3b-11ea-8670-288a99e66438.png) |
