### PR TITLE
Usuwa tokeny do API ze zanonimizowanej bazy.

### DIFF
--- a/db_backups/anonymize.sql
+++ b/db_backups/anonymize.sql
@@ -6,7 +6,7 @@ UPDATE auth_user SET first_name=CONCAT(SUBSTRING(first_name, 1, 1), '_', id);
 UPDATE auth_user SET last_name=CONCAT(SUBSTRING(last_name, 1, 1), '_', id);
 
 -- Delete api tokens
-UPDATE authtoken_token SET key='niepoprawnytoken';
+DELETE FROM authtoken_token;
 
 -- Anonymize/remove email addresses
 UPDATE auth_user SET email='email@example.org';


### PR DESCRIPTION
Wcześniej tokeny nie były usuwane, tylko zamieniano ich wartość. Niestety ta zamiana nie dochodziła do skutku ze względu na constraint UNIQUE na polu `key` w tabeli `authtoken_token`.