### PR TITLE
Zmienia sposób przechowywania biletów w sesji.

### DIFF
--- a/zapisy/apps/grade/poll/signals.py
+++ b/zapisy/apps/grade/poll/signals.py
@@ -47,5 +47,5 @@ def create_poll_for_semester(
 @receiver(user_logged_in)
 def clear_saved_submissions(sender, request, **kwargs):
     """Removes submissions from the active session when user logs in."""
-    if 'grade_poll_submissions' in request.session:
-        del request.session['grade_poll_submissions']
+    if 'grade_poll_tickets' in request.session:
+        del request.session['grade_poll_tickets']

--- a/zapisy/apps/grade/poll/templates/poll/submission.html
+++ b/zapisy/apps/grade/poll/templates/poll/submission.html
@@ -18,40 +18,40 @@
 <div class="row">
   <div class="col-lg-8 col-12 mb-5">
     <div
-      class="card mb-3 {% if grouped_submissions.submitted == grouped_submissions.total%}border-success{% else %}border-danger{% endif %}">
+      class="card mb-3 {% if stats.all %}border-success{% else %}border-danger{% endif %}">
       <div class="card-body">
-        {% if grouped_submissions.submitted == grouped_submissions.total %}
-        <h5 class="card-title">Wypełniłeś wszystkie ankiety!</h5>
-        <p class="card-text">Możesz modyfikować przesłane odpowiedzi przez cały okres trwania oceny wprowadzając pobrane wcześniej klucze dostępu. Jeżeli nie chcesz wprowadzać żadnych poprawek, kliknij poniższy przycisk aby wyczyścić sesję i zakończyć ocenianie.</p>
+        {% if stats.all %}
+          <h5 class="card-title">Wypełniłeś wszystkie ankiety!</h5>
+          <p class="card-text">Możesz modyfikować przesłane odpowiedzi przez cały okres trwania oceny wprowadzając pobrane wcześniej klucze dostępu. Jeżeli nie chcesz wprowadzać żadnych poprawek, kliknij poniższy przycisk aby wyczyścić sesję i zakończyć ocenianie.</p>
         {% else %}
-        <h5 class="card-title">Zadbaj o anonimowość!</h5>
-        <p class="card-text">Ankiety, które właśnie edytujesz są przechowywane w aktywnej sesji. Nie pozwól aby ktoś nieupoważniony uzyskał do nich dostęp –
-          aby tego uniknąć, wystarczy, że wyczyścisz sesję po zakończeniu oceniania.<br>Nie musisz wypełniać od razu wszystkich ankiet. Przez cały okres trwania oceny możesz modyfikować przesłane odpowiedzi wprowadzając pobrane wcześniej klucze dostępu.</p>
+          <h5 class="card-title">Zadbaj o anonimowość!</h5>
+          <p class="card-text">Ankiety, które właśnie edytujesz są przechowywane w aktywnej sesji. Nie pozwól aby ktoś nieupoważniony uzyskał do nich dostęp –
+            aby tego uniknąć, wystarczy, że wyczyścisz sesję po zakończeniu oceniania.<br>Nie musisz wypełniać od razu wszystkich ankiet. Przez cały okres trwania oceny możesz modyfikować przesłane odpowiedzi wprowadzając pobrane wcześniej klucze dostępu.</p>
         {% endif %}
         <div class="row">
           <div class="col">
-            {% if grouped_submissions.submitted %}
-            <div class="progress h-100">
-              <div
-                class="progress-bar {% if grouped_submissions.submitted == grouped_submissions.total%}bg-success{% endif %}"
-                role="progressbar" style="width: calc(100% * ({{ grouped_submissions.progress_numerical|max:0.1 }}))"
-                aria-valuenow="{{ grouped_submissions.submitted }}" aria-valuemin="0"
-                aria-valuemax="{{ grouped_submissions.total }}">
-                <strong>
-                  {{ grouped_submissions.progress }}
-                </strong>
+            {% if stats.submitted %}
+              <div class="progress h-100">
+                <div
+                  class="progress-bar {% if stats.all %}bg-success{% endif %}"
+                  role="progressbar" style="width: calc(100% * {{ stats.progress_numerical|max:0.1 }})"
+                  aria-valuenow="{{ stats.submitted }}" aria-valuemin="0"
+                  aria-valuemax="{{ stats.total }}">
+                  <strong>
+                    {{ stats.progress }}
+                  </strong>
+                </div>
               </div>
-            </div>
             {% else %}
-            <div class="align-middle h-100">Nie wypełniłeś jeszcze żadnej ankiety.</div>
+              <div class="align-middle h-100">Nie wypełniłeś jeszcze żadnej ankiety.</div>
             {% endif %}
           </div>
           <div class="col-auto">
-            {% if grouped_submissions.submitted == grouped_submissions.total%}
-            <a href="{% url 'grade-poll-clear-session' %}" class="btn btn-primary">Zakończ ocenę i wyczyść sesję</a>
+            {% if stats.all %}
+              <a href="{% url 'grade-poll-clear-session' %}" class="btn btn-primary">Zakończ ocenę i wyczyść sesję</a>
             {% else %}
-            <a href="{% url 'grade-poll-clear-session' %}" class="btn btn-dark">Przerwij ocenę i wyczyść
-              sesję</a>
+              <a href="{% url 'grade-poll-clear-session' %}" class="btn btn-dark">Przerwij ocenę i wyczyść
+                sesję</a>
             {% endif %}
           </div>
         </div>
@@ -66,31 +66,33 @@
     </form>
   </div>
   <div class="col-lg-4 col-12">
-    {% for group_name, submissions in grouped_submissions.with_categories.items %}
-    <div
-      class="card {% if grouped_submissions.statuses|lookup:group_name == submissions|length %}list-group-item-success{%else%}text-white bg-secondary{% endif %} mb-3">
-      <div class="card-header">
-        <div class="d-flex w-100 justify-content-between">
-          <span>{{ group_name }}</span>
-          <span class="text-right text-nowrap">{{ grouped_submissions.statuses|lookup:group_name }} /
-            {{ submissions|length }}</span>
+    {% regroup polls by category as polls_by_category %}
+    {% for category, submissions in polls_by_category %}
+      {% with category_submitted=stats.submitted_by_category|lookup:category category_total=submissions|length %}
+        <div
+          class="card {% if category_submitted == category_total %}list-group-item-success{%else%}text-white bg-secondary{% endif %} mb-3">
+          <div class="card-header">
+            <div class="d-flex w-100 justify-content-between">
+              <span>{{ category }}</span>
+              <span class="text-right text-nowrap">{{ category_submitted }} / {{ category_total }}</span>
+            </div>
+          </div>
+          
+          <div class="list-group list-group-flush">
+            {% for entry in submissions %}
+            {% with index=iterator|next %}
+            <a href="{% url 'grade-poll-submissions' submission_index=index %}" type="button"
+            class="list-group-item list-group-item-action {% if current_index == index %} active{% elif entry.submitted %} list-group-item-light{% endif %}">
+            <div class="d-flex w-100 justify-content-between">
+              <span>{{ entry }}</span>
+              <span>{% if entry.submitted %}zapisane{% endif %}</span>
+            </div>
+          </a>
+          {% endwith %}
+          {% endfor %}
         </div>
       </div>
-
-      <div class="list-group list-group-flush">
-        {% for entry in submissions %}
-        {% with index=iterator|next %}
-        <a href="{% url 'grade-poll-submissions' submission_index=index %}" type="button"
-          class="list-group-item list-group-item-action {% if current_index == index %} active{% elif entry.submitted %} list-group-item-light{% endif %}">
-          <div class="d-flex w-100 justify-content-between">
-            <span>{{ entry.submission }}</span>
-            <span>{% if entry.submitted %}zapisane{% endif %}</span>
-          </div>
-        </a>
-        {% endwith %}
-        {% endfor %}
-      </div>
-    </div>
+      {% endwith %}
     {% endfor %}
   </div>
 </div>

--- a/zapisy/apps/grade/poll/utils.py
+++ b/zapisy/apps/grade/poll/utils.py
@@ -26,7 +26,6 @@ class SubmissionStats:
             if s.submitted:
                 self.submitted += 1
                 self.submitted_by_category[s.category] += 1
-                self
 
     @property
     def progress(self) -> str:

--- a/zapisy/apps/grade/poll/utils.py
+++ b/zapisy/apps/grade/poll/utils.py
@@ -1,5 +1,5 @@
-from collections import defaultdict, namedtuple
-from typing import Dict, List, Tuple
+from collections import defaultdict
+from typing import Dict, List
 
 import bokeh.embed
 import bokeh.models.sources
@@ -9,20 +9,6 @@ from apps.enrollment.courses.models.semester import Semester
 from apps.grade.poll.models import Poll, Submission
 from apps.users.models import Student
 
-SubmissionWithStatus = namedtuple('SubmissionWithStatus', ['submission', 'submitted'])
-
-GroupedSubmissions = namedtuple(
-    'GroupedSubmissions',
-    [
-        'with_categories',
-        'statuses',
-        'submitted',
-        'total',
-        'progress',
-        'progress_numerical',
-    ],
-)
-
 
 def check_grade_status() -> bool:
     """Checks whether any of the semesters has grade enabled."""
@@ -30,42 +16,35 @@ def check_grade_status() -> bool:
     return current_semester.is_grade_active
 
 
+class SubmissionStats:
+    """Holds statistics for poll submissions."""
+    def __init__(self, submissions: List[Submission]):
+        self.submitted = 0
+        self.submitted_by_category = defaultdict(int)
+        self.total = len(submissions)
+        for s in submissions:
+            if s.submitted:
+                self.submitted += 1
+                self.submitted_by_category[s.category] += 1
+                self
+
+    @property
+    def progress(self) -> str:
+        return f"{self.submitted} / {self.total}"
+
+    @property
+    def progress_numerical(self) -> float:
+        return self.submitted / self.total
+
+    def all(self) -> bool:
+        return self.submitted == self.total
+
+
 def get_grouped_polls(student: Student) -> Dict:
     """Groups polls into a format used by the grade/ticket_create app."""
     polls = Poll.get_all_polls_for_student(student)
 
     return group_submissions(polls)
-
-
-def group_submissions_with_statuses(
-    submissions: List[SubmissionWithStatus]
-) -> Tuple[dict, dict]:
-    """Groups submissions into a structure that is useful for templating.
-
-    Fields are defined in a `GroupedSubmissions` namedtuple.
-    """
-    grouped_submissions = defaultdict(list)
-    submitted_statuses = defaultdict(int)
-    submitted_count = 0
-
-    for submission_with_status in submissions:
-        submission, status = submission_with_status
-        category = submission.category
-        if category not in submitted_statuses:
-            submitted_statuses[category] = 0
-        grouped_submissions[category].append(submission_with_status)
-        if status:
-            submitted_statuses[category] += 1
-            submitted_count += 1
-
-    return GroupedSubmissions(
-        with_categories=dict(grouped_submissions),
-        statuses=dict(submitted_statuses),
-        submitted=submitted_count,
-        total=len(submissions),
-        progress=f"{submitted_count} / {len(submissions)}",
-        progress_numerical=submitted_count / len(submissions),
-    )
 
 
 def group_submissions(submissions: List[Submission]) -> dict:

--- a/zapisy/templates/grade/base.html
+++ b/zapisy/templates/grade/base.html
@@ -23,7 +23,7 @@
   <a class="nav-link" href="{% url 'grade-poll-results' %}">Wyniki oceny</a>
 </li>
 {% endif %}
-{% if request.session.grade_poll_submissions and not user.is_authenticated %}
+{% if request.session.grade_poll_tickets and not user.is_authenticated %}
 <li class="{% block nav-grade-poll-submissions %}{% endblock %}">
   <a class="nav-link" href="{% url 'grade-poll-submissions' %}">Ankiety</a>
 </li>

--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -289,10 +289,6 @@ SESSION_COOKIE_PATH = '/;HttpOnly'
 SESSION_COOKIE_SECURE = env.bool('SESSION_COOKIE_SECURE', default=False)
 
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
-# Since Django 1.6 the default session serializer is json, which
-# doesn't have as many features, in particular it cannot serialize
-# custom objects, and we need this behavior.
-SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
 # Attach X-XSS-Protection header to all outgoing HTTP responses.
 # It tells conformant browsers to activate their built-in


### PR DESCRIPTION
Gdy student wprowadzi podpisane klucze do oceny zajęć, są one
umieszczane w sesji (w ten sposób można niezalogowanemu użytkownikowi
serwować kolejne widoki). Dotychczas było to zorganizowane następująco:
 1. Po wprowadzeniu biletów serwer generuje/odzyskuje z bazy zgłoszenia
    (Submission).
 2. Zgłoszenia są zapisane w sesji. Są to skomplikowane obiekty,
    dlatego nasz projekt używał PickleSerializer zamiast domyślnego
    JSONSerializer. Lista ta jest zapisana w kolejności biletów (czyli
    kolejności, w której bilety zostały wklejone do formularza).
 3. Powyższy obiekt jest utrzymywany w sesji. W nim pamięta się, które
    ankiety zostały wypełnione, a których jeszcze nie tknięto.
 4. By wyświetlić ankiety w bocznym pasku, używa się funkcji, która
    sortuje je według „kategorii” (przedmiotu).
 5. URL-e adresują ankiety za pomocą pozycji na liście przechowywanej w
    sesji. Co ciekawe, linki na bocznym pasku są generowane w za pomocą
    iteratora, więc jeśli kolejność ankiet na listach z punktów 2 i 4
    jest inna, pojawia się błąd opisany w #926.

Wprowadzona przez nas zmiana polega na tym, że w sesji przechowujemy
tylko bilety (które są bardzo prostym obiektem), a listę ankiet
pobieramy w każdym widoku z bazy. Wbrew pozorom powinno to być
oszczędne, bo obiekty w sesji też są przechowywane w bazie, a dodatkowo
muszą być zdeserializowane. Przez to, że mamy jedną posortowaną listę
ankiet, nie będzie problemów z kolejnością.