### PR TITLE
Poprawka w agregacji archiwalnych głosów w aplikacji „Planowanie”.

### DIFF
--- a/zapisy/apps/offer/plan/utils.py
+++ b/zapisy/apps/offer/plan/utils.py
@@ -250,7 +250,7 @@ def get_subjects_data(subjects: List[Tuple[str, str, int]], years: List[str]) ->
 def get_last_years(n: int) -> List[str]:
     """Lists last n academic years, current included."""
     current_year = SystemState.get_current_state().year
-    last_states = SystemState.objects.filter(year__lte=current_year)[:n]
+    last_states = SystemState.objects.filter(year__lte=current_year).order_by('-year')[:n]
     return [s.year for s in last_states]
 
 


### PR DESCRIPTION
Głosy na propozycje przedmiotów oddane w ostatnich trzech cyklach oferty dydaktycznej są wykorzystywane do ustalenia, jakim zainteresowaniem te przedmioty będą się cieszyć w nadchodzącym roku. W tej zmianie naprawiamy wybór ostatnich trzech lat.