### PR TITLE
Obsługuje przydziały do nieistniejących użytkowników.

### DIFF
--- a/zapisy/apps/offer/assignments/views.py
+++ b/zapisy/apps/offer/assignments/views.py
@@ -66,6 +66,11 @@ def plan_view(request):
         if group_type not in assignments_course_info:
             assignments_course_info[group_type] = CourseGroupTypeSummary(
                 hours=assignment.hours_semester, teachers=set())
+        if assignment.teacher_username not in teachers:
+            messages.warning(
+                request, f"Użytkownik <strong>{assignment.teacher_username}</strong> "
+                "nie występuje w arkuszu <em>Pracownicy</em>. Przydział został pominięty.")
+            continue
         teacher = teachers[assignment.teacher_username]
         assignments_course_info[group_type].teachers.add(
             TeacherInfo(username=assignment.teacher_username,


### PR DESCRIPTION
Przydziały zajęć do użytkowników niewymienionych w arkuszu _Pracownicy_ powinny skutkować ostrzeżeniem, nie błędem HTTP 500.

Fixes #943