### PR TITLE
Zmiana URL schedulera

### DIFF
--- a/zapisy/apps/enrollment/courses/models/group.py
+++ b/zapisy/apps/enrollment/courses/models/group.py
@@ -34,6 +34,7 @@ GroupTooltips = {
     'mat': "zajęcia na matematyce",
     'english': "grupa anglojęzyczna",
     'zdalna': "zajęcia prowadzone zdalnie",
+    'hybrydowa': "zajęcia częściowo zdalne, częściowo stacjonarne",
 }
 
 

--- a/zapisy/apps/enrollment/courses/models/group.py
+++ b/zapisy/apps/enrollment/courses/models/group.py
@@ -34,7 +34,6 @@ GroupTooltips = {
     'mat': "zajęcia na matematyce",
     'english': "grupa anglojęzyczna",
     'zdalna': "zajęcia prowadzone zdalnie",
-    'hybrydowa': "zajęcia częściowo zdalne, częściowo stacjonarne",
 }
 
 

--- a/zapisy/apps/schedulersync/management/commands/import_schedule.py
+++ b/zapisy/apps/schedulersync/management/commands/import_schedule.py
@@ -36,7 +36,8 @@ Instructions for using flags:
         never --dont_delete_terms, never --dry_run
 
 Example usage:
-    python manage.py import_schedule http://scheduler.ii.uni.wroc.pl:8000/scheduler/api/config/wiosna-2020-1/
+    python manage.py import_schedule
+    http://scheduler.ii.uni.wroc.pl:8000/scheduler/api/config/wiosna-2020-1/
     http://scheduler.ii.uni.wroc.pl:8000/scheduler/api/task/096a8260-5151-4491-82a0-f8e43e7be918/
     --semester 1 --dry_run --interactive
 

--- a/zapisy/apps/schedulersync/management/commands/import_schedule.py
+++ b/zapisy/apps/schedulersync/management/commands/import_schedule.py
@@ -44,7 +44,6 @@ Example usage:
 
 """
 
-import collections
 import os
 
 import environ
@@ -59,29 +58,7 @@ from apps.schedulersync.models import TermSyncData
 
 from .scheduler_data import SchedulerData, SZTerm
 from .scheduler_mapper import SchedulerMapper
-from .slack import Slack
-
-
-class Summary:
-    """Holds importing summary.
-
-    Stores information which objects to delete and what to write to Slack and at
-    the end of script.
-    """
-    def __init__(self):
-        self.created_courses = 0
-        self.used_courses = 0
-        self.deleted_courses = []
-        self.updated_terms = []
-        self.created_terms = []
-        self.deleted_terms = []
-        self.used_scheduler_ids = []
-        self.multiple_proposals = []
-        self.maps_added = []
-        self.maps_deleted = []
-
-
-SlackUpdate = collections.namedtuple('Update', ['name', 'old', 'new'])
+from .slack import Slack, Summary, SlackUpdate
 
 
 class Command(BaseCommand):

--- a/zapisy/apps/schedulersync/management/commands/import_schedule.py
+++ b/zapisy/apps/schedulersync/management/commands/import_schedule.py
@@ -36,9 +36,9 @@ Instructions for using flags:
         never --dont_delete_terms, never --dry_run
 
 Example usage:
-    python manage.py import_schedule http://scheduler.gtch.eu/scheduler/api/config/wiosna-2019-2/
-    http://scheduler.gtch.eu/scheduler/api/task/096a8260-5151-4491-82a0-f8e43e7be918/
-    --dry_run --interactive
+    python manage.py import_schedule http://scheduler.ii.uni.wroc.pl:8000/scheduler/api/config/wiosna-2020-1/
+    http://scheduler.ii.uni.wroc.pl:8000/scheduler/api/task/096a8260-5151-4491-82a0-f8e43e7be918/
+    --semester 1 --dry_run --interactive
 
 """
 
@@ -85,11 +85,11 @@ SlackUpdate = collections.namedtuple('Update', ['name', 'old', 'new'])
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('api_config_url', help='Should look like this: '
-                                                   '/scheduler/api/config/2017-18-lato3-2/')
+                                                   '/scheduler/api/config/2020-zima-1/')
         parser.add_argument('api_task_url', help='Should look like this: '
-                                                 'http://scheduler.gtch.eu/scheduler/api/task/'
+                                                 'http://scheduler.ii.uni.wroc.pl:8000/scheduler/api/task/'
                                                  '07164b02-de37-4ddc-b81b-ddedab533fec/')
-        parser.add_argument('-semester', type=int, default=0)
+        parser.add_argument('--semester', type=int, default=0)
         parser.add_argument('--dry_run', action='store_true', help='no changes will be saved. Messages will'
                                                                    ' show up normally as without this flag')
         parser.add_argument('--slack', action='store_true', help='writes messages about changes to Slack')

--- a/zapisy/apps/schedulersync/management/commands/import_schedule.py
+++ b/zapisy/apps/schedulersync/management/commands/import_schedule.py
@@ -36,11 +36,11 @@ Instructions for using flags:
         never --dont_delete_terms, never --dry_run
 
 Example usage:
-    python manage.py import_schedule
-    http://scheduler.ii.uni.wroc.pl:8000
-    wiosna-2020-1
-    096a8260-5151-4491-82a0-f8e43e7be918
-    --semester 1 --dry_run --interactive
+    python manage.py import_schedule \
+        http://scheduler.ii.uni.wroc.pl:8000 \
+        wiosna-2020-1 \
+        096a8260-5151-4491-82a0-f8e43e7be918 \
+        --semester 1 --dry_run --interactive
 
 """
 
@@ -69,7 +69,9 @@ class Command(BaseCommand):
                                                    '2020-zima-1')
         parser.add_argument('api_task_url', help='Should look like this: '
                                                  '07164b02-de37-4ddc-b81b-ddedab533fec')
-        parser.add_argument('--semester', type=int, default=0)
+        parser.add_argument('--semester', type=int, default=0, help='id of the semester to import the schedule'
+                                                                    ' for. If not provided, an upcoming semester'
+                                                                    ' will be guessed (not recommended)')
         parser.add_argument('--dry_run', action='store_true', help='no changes will be saved. Messages will'
                                                                    ' show up normally as without this flag')
         parser.add_argument('--slack', action='store_true', help='writes messages about changes to Slack')

--- a/zapisy/apps/schedulersync/management/commands/scheduler_data.py
+++ b/zapisy/apps/schedulersync/management/commands/scheduler_data.py
@@ -15,8 +15,6 @@ import requests
 
 from apps.enrollment.courses.models.classroom import Classroom
 
-URL_LOGIN = 'http://scheduler.ii.uni.wroc.pl:8000/admin/login/'
-
 # The mapping between group types in scheduler and enrollment system
 # w (wykład), p (pracownia), c (ćwiczenia), s (seminarium), r (ćwiczenio-pracownia),
 # e (repetytorium), o (projekt), t (tutoring), m (proseminarium)
@@ -34,7 +32,8 @@ SZTerm = collections.namedtuple('Term', ['scheduler_id', 'teacher', 'course', 't
 
 
 class SchedulerData:
-    def __init__(self, api_config_url, api_task_url, scheduler_username, scheduler_password):
+    def __init__(self, api_login_url, api_config_url, api_task_url, scheduler_username, scheduler_password):
+        self.api_login_url = api_login_url
         self.api_config_url = api_config_url
         self.api_task_url = api_task_url
         self.scheduler_username = scheduler_username
@@ -95,11 +94,11 @@ class SchedulerData:
         """
         def get_logged_client():
             client = requests.session()
-            client.get(URL_LOGIN)
+            client.get(self.api_login_url)
             cookie = client.cookies['csrftoken']
             login_data = {'username': self.scheduler_username, 'password': self.scheduler_password,
                           'csrfmiddlewaretoken': cookie}
-            client.post(URL_LOGIN, data=login_data)
+            client.post(self.api_login_url, data=login_data)
             return client
 
         def get_results_data(results: 'Dict[int, Dict]') -> 'Dict[int, SchedulerAPIResult]':

--- a/zapisy/apps/schedulersync/management/commands/scheduler_data.py
+++ b/zapisy/apps/schedulersync/management/commands/scheduler_data.py
@@ -15,7 +15,7 @@ import requests
 
 from apps.enrollment.courses.models.classroom import Classroom
 
-URL_LOGIN = 'http://scheduler.gtch.eu/admin/login/'
+URL_LOGIN = 'http://scheduler.ii.uni.wroc.pl:8000/admin/login/'
 
 # The mapping between group types in scheduler and enrollment system
 # w (wykład), p (pracownia), c (ćwiczenia), s (seminarium), r (ćwiczenio-pracownia),

--- a/zapisy/apps/schedulersync/management/commands/slack.py
+++ b/zapisy/apps/schedulersync/management/commands/slack.py
@@ -33,8 +33,8 @@ class Slack:
         }
         self.attachments.append(attachment)
 
-    def prepare_message(self, summary:
-            'apps.schedulersync.management.commands.import_schedule.Summary'):
+    def prepare_message(self, summary: 'apps.schedulersync.management.'
+                                       'commands.import_schedule.Summary'):
         for term in summary.created_terms:
             text = "day: {}\nstart_time: {}\nend_time: {}\nteacher: {}".format(
                 DAYS_OF_WEEK[term.dayOfWeek], term.start_time, term.end_time, term.group.teacher)

--- a/zapisy/apps/schedulersync/management/commands/slack.py
+++ b/zapisy/apps/schedulersync/management/commands/slack.py
@@ -5,11 +5,10 @@ Then sends all collected attachments to Slack or writes onto screen.
 
 """
 
+import collections
 import json
 
 import requests
-
-import apps.schedulersync.management.commands.import_schedule
 
 DAYS_OF_WEEK = {'1': 'monday',
                 '2': 'tuesday',
@@ -18,6 +17,27 @@ DAYS_OF_WEEK = {'1': 'monday',
                 '5': 'friday',
                 '6': 'saturday',
                 '7': 'sunday', }
+
+SlackUpdate = collections.namedtuple('Update', ['name', 'old', 'new'])
+
+
+class Summary:
+    """Holds importing summary.
+
+    Stores information which objects to delete and what to write to Slack and at
+    the end of script.
+    """
+    def __init__(self):
+        self.created_courses = 0
+        self.used_courses = 0
+        self.deleted_courses = []
+        self.updated_terms = []
+        self.created_terms = []
+        self.deleted_terms = []
+        self.used_scheduler_ids = []
+        self.multiple_proposals = []
+        self.maps_added = []
+        self.maps_deleted = []
 
 
 class Slack:
@@ -33,8 +53,7 @@ class Slack:
         }
         self.attachments.append(attachment)
 
-    def prepare_message(self, summary: 'apps.schedulersync.management.'
-                                       'commands.import_schedule.Summary'):
+    def prepare_message(self, summary: Summary):
         for term in summary.created_terms:
             text = "day: {}\nstart_time: {}\nend_time: {}\nteacher: {}".format(
                 DAYS_OF_WEEK[term.dayOfWeek], term.start_time, term.end_time, term.group.teacher)

--- a/zapisy/apps/schedulersync/management/commands/slack.py
+++ b/zapisy/apps/schedulersync/management/commands/slack.py
@@ -9,6 +9,8 @@ import json
 
 import requests
 
+import apps.schedulersync.management.commands.import_schedule
+
 DAYS_OF_WEEK = {'1': 'monday',
                 '2': 'tuesday',
                 '3': 'wednesday',
@@ -31,7 +33,8 @@ class Slack:
         }
         self.attachments.append(attachment)
 
-    def prepare_message(self, summary: 'Summary'):
+    def prepare_message(self, summary:
+            'apps.schedulersync.management.commands.import_schedule.Summary'):
         for term in summary.created_terms:
             text = "day: {}\nstart_time: {}\nend_time: {}\nteacher: {}".format(
                 DAYS_OF_WEEK[term.dayOfWeek], term.start_time, term.end_time, term.group.teacher)

--- a/zapisy/apps/schedulersync/management/commands/slack.py
+++ b/zapisy/apps/schedulersync/management/commands/slack.py
@@ -9,8 +9,6 @@ import json
 
 import requests
 
-from .import_schedule import Summary
-
 DAYS_OF_WEEK = {'1': 'monday',
                 '2': 'tuesday',
                 '3': 'wednesday',

--- a/zapisy/apps/schedulersync/management/commands/syncschedule.sh
+++ b/zapisy/apps/schedulersync/management/commands/syncschedule.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-source /home/zapisy/env36/bin/activate
-cd /home/zapisy/projektzapisy/current/zapisy
-python manage.py import_schedule http://scheduler.ii.uni.wroc.pl/scheduler/api/config/2020-zima-1/ http://scheduler.gtch.eu/scheduler/api/task/f29f280c-28ed-422a-a9d2-316b98eb83e6/ --semester 1 --slack >> logs/import_schedule.log

--- a/zapisy/apps/schedulersync/management/commands/syncschedule.sh
+++ b/zapisy/apps/schedulersync/management/commands/syncschedule.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-source /home/zapisy/env27/bin/activate
+source /home/zapisy/env36/bin/activate
 cd /home/zapisy/projektzapisy/current/zapisy
-python manage.py import_schedule /scheduler/api/config/2017-18-lato3-2/ http://scheduler.gtch.eu/scheduler/api/task/07164b02-de37-4ddc-b81b-ddedab533fec/ --slack --delete-groups >> logs/import_schedule.log
+python manage.py import_schedule http://scheduler.ii.uni.wroc.pl/scheduler/api/config/2020-zima-1/ http://scheduler.gtch.eu/scheduler/api/task/f29f280c-28ed-422a-a9d2-316b98eb83e6/ --semester 1 --slack >> logs/import_schedule.log


### PR DESCRIPTION
Zmienia URL schedulera w dokumentacji i przykładach na aktualnie obowiązujący.
Usuwa cykliczny import poprzez przeniesienie klasy Summary.
Ulepsza CLI (adres serwera przekazywany raz, nie jest wpisany nigdzie w kodzie).