### PR TITLE
Dodaje tooltip dla tagu grup hybrydowych

### DIFF
--- a/zapisy/apps/enrollment/courses/models/group.py
+++ b/zapisy/apps/enrollment/courses/models/group.py
@@ -34,6 +34,7 @@ GroupTooltips = {
     'mat': "zajęcia na matematyce",
     'english': "grupa anglojęzyczna",
     'zdalna': "zajęcia prowadzone zdalnie",
+    'hybrydowa': "zajęcia częściowo zdalne, częściowo stacjonarne",
 }
 
 


### PR DESCRIPTION
Ta zmiana dodaje krótki opis dla grup z tagiem 'hybrydowa'. Grupy zdalne miały taki opis już wcześniej.