### PR TITLE
Poprawka do scalania grup wykładowych przy imporcie planu.

### DIFF
--- a/zapisy/apps/schedulersync/management/commands/import_schedule.py
+++ b/zapisy/apps/schedulersync/management/commands/import_schedule.py
@@ -143,8 +143,12 @@ class Command(BaseCommand):
         except TermSyncData.DoesNotExist:
             # The lecture always has a single group but possibly many terms.
             if term_data.type == GroupType.LECTURE:
-                group, _ = Group.objects.get_or_create(course=term_data.course, teacher=term_data.teacher,
-                                                       type=term_data.type, limit=term_data.limit)
+                group, _ = Group.objects.get_or_create(course=term_data.course,
+                                                       type=term_data.type,
+                                                       defaults={
+                                                           'teacher': term_data.teacher,
+                                                           'limit': term_data.limit,
+                                                       })
             else:
                 group = Group.objects.create(course=term_data.course, teacher=term_data.teacher,
                                              type=term_data.type, limit=term_data.limit)


### PR DESCRIPTION
Od wejścia PR #891, zmiany w limitach miejsc wprowadzane są po stronie Systemu Zapisów, a nie Schedulera. Dlatego nie należy podawać limitu grupy jako parametru poszukiwania. Jeśli chcemy, by grupa wykładowa autentycznie nie była zdublowana, musimy szukać jej tylko po parametrach (przedmiot, typ).