### PR TITLE
Odpala auto-zapisy po modyfikacji grupy.

### DIFF
--- a/zapisy/apps/enrollment/records/tasks.py
+++ b/zapisy/apps/enrollment/records/tasks.py
@@ -74,5 +74,7 @@ def group_save_signal_receiver(sender, instance, created, raw, using, **kwargs):
         return
     if not settings.RUN_ASYNC:
         pull_from_queue(group_id)
+        update_auto_enrollment_groups(group_id)
     else:
         pull_from_queue.delay(group_id)
+        update_auto_enrollment_groups.delay(group_id)


### PR DESCRIPTION
Gdy grupa zostanie zmodyfikowana (na przykład ktoś zapisze lub usunie studenta w panelu admina), należy odpalić funkcję, która zaktualizuje auto-zapis w grupach z tego samego przedmiotu.

W szczególności, żeby odpalić grupy automatyczne, wystarczy wejść w panelu admina do jakiejkolwiek grupy z odpowiedniego przedmiotu i kliknąć „Zapisz”.