### PR TITLE
Usunięcie tagu <base> z base.html

### DIFF
--- a/zapisy/templates/base.html
+++ b/zapisy/templates/base.html
@@ -9,7 +9,6 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <base href="{% url 'main-page' %}">
     <title>{% block main-subtitle %}{% endblock %} &ndash; {% block title %}System Zapisów{% endblock %}</title>
     <meta name="description" content="System obsługi cyklu dydaktycznego Instytut Informatyki Uniwersytetu Wrocławskiego">
 


### PR DESCRIPTION
`<base href="{% url 'main-page' %}">` w base.html ustawia adres `https://zapisy.ii.uni.wroc.pl/` jako podstawowy dla wszystkich względnych adresów URL. Przez to użycie np. https://github.com/iiuni/projektzapisy/blob/25a969493ec5443b7247e706a5a18e4ebbe0241f/zapisy/apps/offer/assignments/templates/assignments/view.html#L17 zamiast skierować na `/offer/assignments/#section-by-course` kieruje na `/#section-by-course`. 

_________________
Fixes #977 
Fixes #992 