### PR TITLE
Naprawia generowanie termów i eksport planu zajęć

### DIFF
--- a/zapisy/apps/enrollment/timetable/views.py
+++ b/zapisy/apps/enrollment/timetable/views.py
@@ -293,7 +293,7 @@ def calendar_export(request):
     """Exports user's timetable for import in Google Calendar."""
     semester = Semester.get_upcoming_semester()
     groups = Group.objects.filter(course__semester=semester).filter(
-        Q(teacher__user=request.user) | Q(record__student__user=request.user))
+        Q(teacher__user=request.user) | Q(record__student__user=request.user), Q(record__status='1'))
     terms = SchTerm.objects.filter(event__group__in=groups).select_related(
         'event__group', 'event__group__course', 'event__group__teacher',
         'event__group__teacher__user', 'room')

--- a/zapisy/apps/enrollment/timetable/views.py
+++ b/zapisy/apps/enrollment/timetable/views.py
@@ -305,10 +305,13 @@ def calendar_export(request):
         ['Subject', 'Start Date', 'Start Time', 'End Date', 'End Time', 'Location', 'Description'])
     for term in terms:
         group = term.event.group
-        room = term.room
+        if not term.room:
+            classroom = "Zajęcia zdalne"
+        else:
+            classroom = f"Sala {term.room}"
 
         name = f"{group.course.name} - {group.get_type_display()}"
-        location = f"Sala {room.number}, Instytut Informatyki Uniwersytetu Wrocławskiego"
+        location = f"{classroom}, Instytut Informatyki Uniwersytetu Wrocławskiego"
         description = f"Prowadzący: {group.get_teacher_full_name()}"
         writer.writerow([name, term.day, term.start, term.day, term.end, location, description])
     return response

--- a/zapisy/apps/enrollment/timetable/views.py
+++ b/zapisy/apps/enrollment/timetable/views.py
@@ -293,7 +293,7 @@ def calendar_export(request):
     """Exports user's timetable for import in Google Calendar."""
     semester = Semester.get_upcoming_semester()
     groups = Group.objects.filter(course__semester=semester).filter(
-        Q(teacher__user=request.user) | Q(record__student__user=request.user), Q(record__status='1'))
+        Q(teacher__user=request.user) | Q(record__student__user=request.user, record__status=RecordStatus.ENROLLED))
     terms = SchTerm.objects.filter(event__group__in=groups).select_related(
         'event__group', 'event__group__course', 'event__group__teacher',
         'event__group__teacher__user', 'room')

--- a/zapisy/apps/schedule/models/term.py
+++ b/zapisy/apps/schedule/models/term.py
@@ -231,8 +231,7 @@ def delete_course_terms(**kwargs):
     matching_terms = Term.objects.filter(event__group=instance.group,
                                          day__in=dates,
                                          start=instance.start_time,
-                                         end=instance.end_time,
-                                         room__in=instance.classrooms.all())
+                                         end=instance.end_time)
     matching_terms.delete()
 
 

--- a/zapisy/apps/schedule/models/term.py
+++ b/zapisy/apps/schedule/models/term.py
@@ -254,16 +254,15 @@ def create_course_terms(**kwargs):
                                            author=instance.group.teacher.user)
     for day in dates:
         rooms = instance.classrooms.all()
+        for room in rooms:
+            Term.objects.create(event=event,
+                                day=day,
+                                start=instance.start_time,
+                                end=instance.end_time,
+                                room=room)
         if not rooms:
             Term.objects.create(event=event,
                                 day=day,
                                 start=instance.start_time,
                                 end=instance.end_time,
                                 room=None)
-        else:
-            for room in rooms:
-                Term.objects.create(event=event,
-                                    day=day,
-                                    start=instance.start_time,
-                                    end=instance.end_time,
-                                    room=room)

--- a/zapisy/apps/schedule/models/term.py
+++ b/zapisy/apps/schedule/models/term.py
@@ -254,9 +254,17 @@ def create_course_terms(**kwargs):
                                            status=Event.STATUS_ACCEPTED,
                                            author=instance.group.teacher.user)
     for day in dates:
-        for room in instance.classrooms.all():
+        rooms = instance.classrooms.all()
+        if not rooms:
             Term.objects.create(event=event,
                                 day=day,
                                 start=instance.start_time,
                                 end=instance.end_time,
-                                room=room)
+                                room=None)
+        else:
+            for room in rooms:
+                Term.objects.create(event=event,
+                                    day=day,
+                                    start=instance.start_time,
+                                    end=instance.end_time,
+                                    room=room)


### PR DESCRIPTION
1. Naprawione generowanie termów (`schedule.Term`) odpowiadających zajęciom (`courses.Term`) które nie mają przypisanej ani jednej sali.
2. Naprawiony wybór przedmiotów użytkownika przy eksporcie planu zajęć.

Fixes #988 