### PR TITLE
Naprawia filtrowanie kursów po semestrze we wrapperze API.

### DIFF
--- a/zapisy/apps/api/rest/v1/api_wrapper/sz_api/sz_api.py
+++ b/zapisy/apps/api/rest/v1/api_wrapper/sz_api/sz_api.py
@@ -92,7 +92,7 @@ class ZapisyApi:
             semester_id: Only courses for the semester are listed if provided.
         """
         return self._get_deserialized_data(
-            CourseInstance, params={"semester_id": semester_id})
+            CourseInstance, params={"semester": semester_id})
 
     def course(self, id: int) -> CourseInstance:
         """Returns course with a given id."""

--- a/zapisy/apps/api/rest/v1/tests/test_wrapper.py
+++ b/zapisy/apps/api/rest/v1/tests/test_wrapper.py
@@ -169,6 +169,14 @@ class WrapperTests(APILiveServerTestCase):
         self.assertEqual(res_course.course_type, course.course_type.short_name)
         self.assertEqual(res_course.usos_kod, course.usos_kod)
 
+    def test_courses_filter_semester(self):
+        """Tests filtering courses by semester."""
+        course1 = CourseInstanceFactory()
+        course2 = CourseInstanceFactory()
+        [res_course] = list(self.wrapper.courses(semester_id=course2.semester_id))
+        self.assertEqual(res_course.id, course2.id)
+        self.assertNotEqual(res_course.semester, course1.semester_id)
+
     def test_classroom(self):
         """Tests classroom handling.
 


### PR DESCRIPTION
Polem zdefiniowanym w API dla modelu Course jest `semester`, a nie `semester_id`.