### PR TITLE
Zmiany w filtrach i liście prac dyplomowych

### DIFF
--- a/zapisy/apps/theses/assets/components/ThesesList.vue
+++ b/zapisy/apps/theses/assets/components/ThesesList.vue
@@ -52,6 +52,13 @@ export default class ThesesList extends Vue {
       }
     });
   }
+
+  reservedUntilAltText(thesis: ThesisInfo): string | undefined {
+    if (!thesis.reserved_until) {
+      return undefined;
+    }
+    return `Zarezerwowana do ${thesis.reserved_until}`;
+  }
 }
 </script>
 
@@ -84,7 +91,7 @@ export default class ThesesList extends Vue {
       <tr v-for="t of visibleTheses" :key="t.id">
         <td class="align-middle">
           <a class="btn-link" :href="t.url">{{ t.title }}</a>
-          <em v-if="!t.has_been_accepted" class="text-muted"
+          <em v-if="t.status !== 'zaakceptowana'" class="text-muted"
             >({{ t.status }})</em
           >
         </td>
@@ -94,7 +101,11 @@ export default class ThesesList extends Vue {
         <td class="align-middle">
           {{ t.advisor }}
         </td>
-        <td class="align-middle" :class="{ 'text-muted': t.is_available }">
+        <td
+          class="align-middle"
+          :class="{ 'text-muted': t.is_available }"
+          :title="reservedUntilAltText(t)"
+        >
           {{ t.students }}
         </td>
       </tr>

--- a/zapisy/apps/theses/assets/components/ThesesList.vue
+++ b/zapisy/apps/theses/assets/components/ThesesList.vue
@@ -65,7 +65,7 @@ export default class ThesesList extends Vue {
 </style>
 
 <template>
-  <table class="table table-hover selection-none">
+  <table class="table table-hover selection-none table-responsive-md">
     <thead id="table-header">
       <tr class="text-center">
         <th>
@@ -91,7 +91,7 @@ export default class ThesesList extends Vue {
         <td class="text-center align-middle">
           {{ t.kind }}
         </td>
-        <td class="align-middle text-nowrap">
+        <td class="align-middle">
           {{ t.advisor }}
         </td>
         <td class="align-middle" :class="{ 'text-muted': t.is_available }">

--- a/zapisy/apps/theses/assets/components/ThesisFilter.vue
+++ b/zapisy/apps/theses/assets/components/ThesisFilter.vue
@@ -67,14 +67,14 @@ export default Vue.extend({
         </div>
       </div>
       <div class="row">
-        <div class="col-lg-3">
+        <div class="col-lg-4">
           <CheckFilter
             filterKey="available-filter"
             property="is_available"
-            label="Pokaż tylko dostępne prace"
+            label="Pokaż tylko niezarezerwowane prace"
           />
         </div>
-        <div class="col-lg-3">
+        <div class="col-lg-4">
           <CheckFilter
             filterKey="mine-filter"
             property="is_mine"

--- a/zapisy/apps/theses/assets/components/ThesisFilter.vue
+++ b/zapisy/apps/theses/assets/components/ThesisFilter.vue
@@ -14,7 +14,7 @@ export default Vue.extend({
   data: function () {
     return {
       allKinds: [] as [string, string][],
-      allStatuses: [] as [number, string][],
+      allStatuses: [] as [string, string][],
     };
   },
   created: function () {
@@ -27,8 +27,11 @@ export default Vue.extend({
       ["lic+inż+isim", "Licencjat+inżynierska+ISIM"],
     ];
     this.allStatuses = [
-      [0, "W trakcie weryfikacji"],
-      [1, "Zaakceptowane"],
+      ["weryfikowana przez komisję", "Weryfikowana przez komisję"],
+      ["zwrócona do poprawek", "Zwrócona do poprawek"],
+      ["zaakceptowana", "Zaakceptowana"],
+      ["w realizacji", "W realizacji"],
+      ["obroniona", "Obroniona"],
     ];
   },
 });
@@ -38,21 +41,14 @@ export default Vue.extend({
   <div class="card bg-light">
     <div class="card-body">
       <div class="row">
-        <div class="col-lg">
+        <div class="col-lg-6">
           <TextFilter
             filterKey="title-filter"
-            property="title"
-            placeholder="Nazwa pracy dyplomowej"
+            :properties="['title', 'advisor', 'students']"
+            placeholder="Nazwa, promotor, studenci"
           />
         </div>
-        <div class="col-lg">
-          <TextFilter
-            filterKey="advisor-filter"
-            property="advisor"
-            placeholder="Promotor"
-          />
-        </div>
-        <div class="col-lg">
+        <div class="col-lg-3">
           <SelectFilter
             filterKey="kind-filter"
             property="kind"
@@ -60,23 +56,31 @@ export default Vue.extend({
             placeholder="Typ pracy dyplomowej"
           />
         </div>
+        <div class="col-lg-3">
+          <SelectFilter
+            filterKey="status-filter"
+            property="status"
+            :options="allStatuses"
+            default="zaakceptowana"
+            placeholder="Status pracy dyplomowej"
+          />
+        </div>
       </div>
       <div class="row">
-        <div class="col-lg">
+        <div class="col-lg-3">
           <CheckFilter
             filterKey="available-filter"
             property="is_available"
             label="Pokaż tylko dostępne prace"
           />
         </div>
-        <div class="col-lg">
+        <div class="col-lg-3">
           <CheckFilter
             filterKey="mine-filter"
             property="is_mine"
             label="Pokaż tylko moje"
           />
         </div>
-        <div class="col-lg"></div>
       </div>
     </div>
   </div>

--- a/zapisy/apps/theses/assets/components/filters/SelectFilter.vue
+++ b/zapisy/apps/theses/assets/components/filters/SelectFilter.vue
@@ -6,7 +6,10 @@ import { mapMutations } from "vuex";
 import { Filter } from "../../store/filters";
 
 class ExactFilter implements Filter {
-  constructor(public option: number | undefined, public propertyName: string) {}
+  constructor(
+    public option: number | string | undefined,
+    public propertyName: string
+  ) {}
 
   visible(c: Object): boolean {
     if (this.option === undefined) {
@@ -25,19 +28,23 @@ export default Vue.extend({
     property: String,
     // Every filter needs a unique identifier.
     filterKey: String,
-    options: Array as () => [number, string][],
+    default: String as () => number | string | undefined,
+    options: Array as () => [number | string, string][],
     placeholder: String,
   },
   data: () => {
     return {
-      selected: undefined,
+      selected: undefined as number | string | undefined,
     };
   },
   methods: {
     ...mapMutations("filters", ["registerFilter"]),
   },
+  mounted: function () {
+    this.selected = this.default;
+  },
   watch: {
-    selected: function (newSelected: number | undefined) {
+    selected: function (newSelected: number | string | undefined) {
       this.registerFilter({
         k: this.filterKey,
         f: new ExactFilter(newSelected, this.property),

--- a/zapisy/apps/theses/assets/store/theses.ts
+++ b/zapisy/apps/theses/assets/store/theses.ts
@@ -9,7 +9,6 @@ export interface ThesisInfo {
   kind: string;
   status: string;
   modified: number;
-  has_been_accepted: boolean;
   advisor: string;
   advisor_last_name: string;
   students: string;

--- a/zapisy/apps/theses/assets/store/theses.ts
+++ b/zapisy/apps/theses/assets/store/theses.ts
@@ -5,7 +5,7 @@ export interface ThesisInfo {
   id: number;
   title: string;
   is_available: boolean;
-  reserved_until: string,
+  reserved_until: string;
   kind: string;
   status: string;
   modified: number;

--- a/zapisy/apps/theses/assets/store/theses.ts
+++ b/zapisy/apps/theses/assets/store/theses.ts
@@ -5,6 +5,7 @@ export interface ThesisInfo {
   id: number;
   title: string;
   is_available: boolean;
+  reserved_until: string,
   kind: string;
   status: string;
   modified: number;

--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -119,6 +119,9 @@ class Thesis(models.Model):
     def is_supporting_advisor_assigned(self, user):
         return self.supporting_advisor is not None and user == self.supporting_advisor.user
 
+    def is_among_advisors(self, user):
+        return self.is_mine(user) or self.is_supporting_advisor_assigned(user)
+
     @property
     def has_no_students_assigned(self):
         return self.students is not None and not self.students.exists()

--- a/zapisy/apps/theses/templates/theses/thesis.html
+++ b/zapisy/apps/theses/templates/theses/thesis.html
@@ -183,7 +183,7 @@
 
         <h2 class="mt-4">Uwagi</h2>
         {% if board_member %}
-            {% if not_has_been_accepted %}
+            {% if not thesis.has_been_accepted %}
                 <h4>Edytuj swoją uwagę</h4>
                 <form action="{% url 'theses:remark_thesis' thesis.id %}" method="POST" class="post-form">
                     {% csrf_token %}

--- a/zapisy/apps/theses/views.py
+++ b/zapisy/apps/theses/views.py
@@ -30,7 +30,7 @@ def list_all(request):
         has_been_accepted = p.has_been_accepted
         is_mine = p.is_mine(request.user) or p.is_student_assigned(
             request.user) or p.is_supporting_advisor_assigned(request.user)
-        advisor = p.advisor.__str__()
+        advisor = str(p.advisor) + (f" ({p.supporting_advisor})" if p.supporting_advisor else "")
         advisor_last_name = p.advisor.user.last_name if p.advisor else p.advisor.__str__()
         students = ", ".join(s.get_full_name() for s in p.students.all())
         url = reverse('theses:selected_thesis', None, [str(p.id)])

--- a/zapisy/apps/theses/views.py
+++ b/zapisy/apps/theses/views.py
@@ -24,7 +24,7 @@ def list_all(request):
     theses_list = []
     for p in visible_theses:
         title = p.title
-        is_available = not p.is_reserved and p.status == ThesisStatus.ACCEPTED
+        is_available = not p.is_reserved
         kind = p.get_kind_display()
         status = p.get_status_display()
         has_been_accepted = p.has_been_accepted

--- a/zapisy/apps/theses/views.py
+++ b/zapisy/apps/theses/views.py
@@ -24,7 +24,7 @@ def list_all(request):
     theses_list = []
     for p in visible_theses:
         title = p.title
-        is_available = not p.is_reserved
+        is_available = not p.is_reserved and p.status == ThesisStatus.ACCEPTED
         kind = p.get_kind_display()
         status = p.get_status_display()
         has_been_accepted = p.has_been_accepted
@@ -39,6 +39,7 @@ def list_all(request):
             'id': p.id,
             'title': title,
             'is_available': is_available,
+            'reserved_until': p.reserved_until,
             'kind': kind,
             'status': status,
             'has_been_accepted': has_been_accepted,


### PR DESCRIPTION
Niewielkie zmiany mające na celu wprowadzenie większej klarowności w zakresie statusu i dostępności tematów prac dyplomowych. Niektóre z tych zmian są efektem uwag wyrażonych przez p. prodziekan.

![image](https://user-images.githubusercontent.com/5896456/97560957-b0d3bd00-19df-11eb-82fc-db1875a34ffd.png)
![image](https://user-images.githubusercontent.com/5896456/97561079-e4aee280-19df-11eb-9b7d-53f525b02334.png)


## Opis zmian:

1. Bardziej istotny jest _status_ tematu pracy dyplomowej. Wszystkie tematy o statusie innym niż `zaakceptowana` mają odpowiedni opis. Filtr pozwala filtrować po statusie, i co więcej, domyślnie pokazywane są tylko prace o statusie `zaakceptowana` (bo tylko takie powinny interesować większość studentów).
2. W polu tekstowym można filtrować po tytule oraz nazwiskach (studentów i promotorów). Semantyka filtra jest taka, że każdy token (wyraz) wyszukiwanego tekstu musi odpowiadać przynajmniej jednemu z tych trzech pól.
3. „Pokaż tylko dostępne prace” zmieniamy na „Pokaż tylko niezarezerwowane prace”. Przy rezerwacji, po najechaniu myszą widzimy termin rezerwacji.
4. W kodzie widoków warunki odpowiadające za uprawnienia dostępu są zaimplementowane nieco jaśniej.
5. Usunięto kilka zbędnych dekoratorów.