### PR TITLE
Większe przyciski na prototypie 

### DIFF
--- a/zapisy/apps/common/assets/main/icons-library.js
+++ b/zapisy/apps/common/assets/main/icons-library.js
@@ -25,13 +25,13 @@ import { faCarSide } from "@fortawesome/free-solid-svg-icons/faCarSide";
 library.add(faCarSide);
 
 import { faThumbtack } from "@fortawesome/free-solid-svg-icons/faThumbtack";
-library.add(faThumbtack)
+library.add(faThumbtack);
 
 import { faBan } from "@fortawesome/free-solid-svg-icons/faBan";
-library.add(faBan)
+library.add(faBan);
 
 import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt";
-library.add(faPencilAlt)
+library.add(faPencilAlt);
 
 // This allows us to include an icon with <i class="fa fa-[ICON-NAME]"></i>.
 dom.watch();

--- a/zapisy/apps/common/assets/main/icons-library.js
+++ b/zapisy/apps/common/assets/main/icons-library.js
@@ -24,5 +24,14 @@ library.add(faMinus);
 import { faCarSide } from "@fortawesome/free-solid-svg-icons/faCarSide";
 library.add(faCarSide);
 
+import { faThumbtack } from "@fortawesome/free-solid-svg-icons/faThumbtack";
+library.add(faThumbtack)
+
+import { faBan } from "@fortawesome/free-solid-svg-icons/faBan";
+library.add(faBan)
+
+import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt";
+library.add(faPencilAlt)
+
 // This allows us to include an icon with <i class="fa fa-[ICON-NAME]"></i>.
 dom.watch();

--- a/zapisy/apps/enrollment/timetable/assets/components/Term.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/Term.vue
@@ -88,7 +88,7 @@ export default class TermComponent extends TermProps {
 </script>
 
 <template>
-  <div class="term-box" :style="boxStyle" :class="boxClass">
+  <div class="term-box" :style="boxStyle" :class="boxClass" ref="root">
     <div class="term-info" :title="title" @click="showPopup()">
       <span class="short-name">{{ courseShortName }}</span>
       <span class="teacher">{{ group.teacher.name }}</span>
@@ -97,7 +97,7 @@ export default class TermComponent extends TermProps {
     </div>
 
     <transition name="fade">
-      <div v-if="popupVisible" class="popup" @mouseleave="hidePopup()">
+      <div v-if="popupVisible" class="popup" @mouseleave="hidePopup">
         <span class="popup-name">
           <a :href="group.course.url">{{ group.course.name }}</a>
         </span>
@@ -238,6 +238,9 @@ export default class TermComponent extends TermProps {
   background: #f8f8f8;
   overflow: hidden;
   box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.15);
+  @media (max-width: 992px) {
+    top: 75%;
+  }
 }
 
 .popup-name {

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -147,14 +147,15 @@ export default class TermControlsComponent extends TermControlsProps {
 .controls {
   background: white;
 
-  position: relative;
+  position: absolute;
   top: 0;
   left: 0;
   max-height: 100%;
 
-  display: inline-grid;
-  grid-auto-flow: column;
-  grid-template-rows: repeat(auto-fit, 26px);
+  display: inline-flex;
+  writing-mode: vertical-lr;
+  flex-wrap: wrap;
+  align-content: flex-start;
 
   cursor: default;
   border: 1px solid #666666;
@@ -168,7 +169,6 @@ export default class TermControlsComponent extends TermControlsProps {
 .controls span {
   padding: 3px;
   font-size: 20px;
-  overflow: hidden;
   cursor: pointer;
 }
 
@@ -176,15 +176,15 @@ export default class TermControlsComponent extends TermControlsProps {
   .controls {
     background: white;
 
-    position: relative;
+    position: absolute;
     top: 0;
     left: 0;
     max-height: 100%;
     max-width: 100%;
 
-    display: inline-flex;
-    flex-direction: row;
-    flex-wrap: wrap;
+    display: inline-grid;
+    grid-auto-flow: row;
+    grid-template-rows: repeat(auto-fit, 33px);
 
     cursor: default;
     border: 1px solid #666666;
@@ -197,8 +197,7 @@ export default class TermControlsComponent extends TermControlsProps {
 
   .controls span {
     padding: 3px;
-    font-size: 28px;
-    overflow: hidden;
+    font-size: 30px;
     cursor: pointer;
   }
 }

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -173,6 +173,7 @@ export default class TermControlsComponent extends TermControlsProps {
 @media (max-width: 992px) {
   .controls {
     position: absolute;
+    min-width: 54px;
     max-width: 100%;
 
     display: grid;

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -5,7 +5,7 @@
 import Component from "vue-class-component";
 import Vue from "vue";
 import TermComponent from "./Term.vue";
-import { library } from "@fortawesome/fontawesome-svg-core";
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCarSide } from "@fortawesome/free-solid-svg-icons/faCarSide";
 import { faThumbtack } from "@fortawesome/free-solid-svg-icons/faThumbtack";
 import { faBan } from "@fortawesome/free-solid-svg-icons/faBan";
@@ -95,11 +95,7 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Odepnij grupę od planu."
           @click="unpin()"
         >
-          <font-awesome-icon
-            icon="thumbtack"
-            transform="left-1 shrink-3"
-            rotation="90"
-          />
+          <font-awesome-icon icon="thumbtack" transform="right-2" rotation="90"/>
         </span>
         <span
           v-else
@@ -107,7 +103,7 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Przypnij grupę do planu."
           @click="pin()"
         >
-          <font-awesome-icon icon="thumbtack" transform="right-1 shrink-2" />
+          <font-awesome-icon icon="thumbtack" transform="right-2"/>
         </span>
 
         <span
@@ -171,38 +167,33 @@ export default class TermControlsComponent extends TermControlsProps {
 }
 
 .controls span {
-  padding: 3px;
-  font-size: 20px;
+  display: block;
+  width: 18px;
+  height: 18px;
+  margin: 3px;
+  overflow: hidden;
   cursor: pointer;
 }
+</style>
 
-@media (max-width: 992px) {
-  .controls {
-    background: white;
+<style lang="scss">
+$icons-size: 18px;
+span.pin {
+  font-size: $icons-size;
+}
 
-    position: absolute;
-    top: 0;
-    left: 0;
-    max-height: 100%;
-    max-width: 100%;
+span.unpin {
+  font-size: $icons-size;
+}
 
-    display: inline-grid;
-    grid-auto-flow: row;
-    grid-template-rows: repeat(auto-fit, 33px);
+span.enqueue {
+  font-size: $icons-size;
+}
 
-    cursor: default;
-    border: 1px solid #666666;
-    border-top: 0;
-    border-left: 0;
-    border-radius: 4px 0;
-    box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
-    z-index: 30;
-  }
-
-  .controls span {
-    padding: 3px;
-    font-size: 30px;
-    cursor: pointer;
-  }
+span.dequeue {
+  font-size: $icons-size;
+}
+span.auto-enrollment {
+  font-size: $icons-size;
 }
 </style>

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -95,7 +95,7 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Odepnij grupę od planu."
           @click="unpin()"
         >
-          <font-awesome-icon icon="thumbtack" transform="right-2" rotation="90"/>
+          <font-awesome-icon icon="thumbtack" transform="left-1 shrink-3" rotation="90"/>
         </span>
         <span
           v-else
@@ -103,7 +103,7 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Przypnij grupę do planu."
           @click="pin()"
         >
-          <font-awesome-icon icon="thumbtack" transform="right-2"/>
+          <font-awesome-icon icon="thumbtack" transform="right-1 shrink-2"/>
         </span>
 
         <span
@@ -147,15 +147,14 @@ export default class TermControlsComponent extends TermControlsProps {
 .controls {
   background: white;
 
-  position: absolute;
+  position: relative;
   top: 0;
   left: 0;
   max-height: 100%;
 
-  display: inline-flex;
-  writing-mode: vertical-lr;
-  flex-wrap: wrap;
-  align-content: flex-start;
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(auto-fit, 26px);
 
   cursor: default;
   border: 1px solid #666666;
@@ -167,33 +166,40 @@ export default class TermControlsComponent extends TermControlsProps {
 }
 
 .controls span {
-  display: block;
-  width: 18px;
-  height: 18px;
-  margin: 3px;
+  padding: 3px;
+  font-size: 20px;
   overflow: hidden;
   cursor: pointer;
 }
-</style>
 
-<style lang="scss">
-$icons-size: 18px;
-span.pin {
-  font-size: $icons-size;
-}
+@media(max-width: 992px) {
+  .controls {
+    background: white;
 
-span.unpin {
-  font-size: $icons-size;
-}
+    position: relative;
+    top: 0;
+    left: 0;
+    max-height: 100%;
+    max-width: 100%;
 
-span.enqueue {
-  font-size: $icons-size;
-}
+    display: inline-flex;
+    flex-direction: row;
+    flex-wrap: wrap;
 
-span.dequeue {
-  font-size: $icons-size;
-}
-span.auto-enrollment {
-  font-size: $icons-size;
+    cursor: default;
+    border: 1px solid #666666;
+    border-top: 0;
+    border-left: 0;
+    border-radius: 4px 0;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
+    z-index: 30;
+  }
+
+  .controls span {
+    padding: 3px;
+    font-size: 28px;
+    overflow: hidden;
+    cursor: pointer;
+  }
 }
 </style>

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -5,10 +5,16 @@
 import Component from "vue-class-component";
 import Vue from "vue";
 import TermComponent from "./Term.vue";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCarSide } from "@fortawesome/free-solid-svg-icons/faCarSide";
+import { faThumbtack } from "@fortawesome/free-solid-svg-icons/faThumbtack";
+import { faBan } from "@fortawesome/free-solid-svg-icons/faBan";
+import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 import { Term, Group } from "../models";
+
+library.add(faCarSide, faThumbtack, faBan, faPencilAlt);
 
 const TermControlsProps = Vue.extend({
   props: {
@@ -24,7 +30,6 @@ const TermControlsProps = Vue.extend({
 })
 export default class TermControlsComponent extends TermControlsProps {
   controlsVisible: boolean = false;
-  faCarSide = faCarSide;
 
   get group(): Group {
     return this.term.group;
@@ -89,26 +94,34 @@ export default class TermControlsComponent extends TermControlsProps {
           class="unpin"
           title="Odepnij grupę od planu."
           @click="unpin()"
-        ></span>
+        >
+          <font-awesome-icon icon="thumbtack" transform="right-2" rotation="90"/>
+        </span>
         <span
           v-else
           class="pin"
           title="Przypnij grupę do planu."
           @click="pin()"
-        ></span>
+        >
+          <font-awesome-icon icon="thumbtack" transform="right-2"/>
+        </span>
 
         <span
           v-if="canEnqueue"
           class="enqueue"
           title="Zapisz do grupy/kolejki."
           @click="enqueue()"
-        ></span>
+        >
+          <font-awesome-icon icon="pencil-alt" transform="shrink-2" />
+        </span>
         <span
           v-if="canDequeue"
           class="dequeue"
           title="Wypisz z grupy/kolejki."
           @click="dequeue()"
-        ></span>
+        >
+          <font-awesome-icon icon="ban" transform="shrink-2" />
+        </span>
         <span
           v-if="term.group.autoEnrollment"
           class="auto-enrollment"
@@ -148,8 +161,8 @@ export default class TermControlsComponent extends TermControlsProps {
 
 .controls span {
   display: block;
-  width: 12px;
-  height: 12px;
+  width: 18px;
+  height: 18px;
   margin: 3px;
   overflow: hidden;
   cursor: pointer;
@@ -157,22 +170,23 @@ export default class TermControlsComponent extends TermControlsProps {
 </style>
 
 <style lang="scss">
+$icons-size: 18px;
 span.pin {
-  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAQAAAD8fJRsAAAAi0lEQVQY032PMQoCUQxEg4iCdgoK2qlvDmLhWfYydl5AbLyXIh9stnKxSSw+f11FTCAE3gzDmP0f9SVNfwA2aji3sqFmbxCq2asicdWDKJoVoY81DRiz1JYg5HJCnkHiTsMT/3KYmbFoHSHPXwlfKxQE+bpKOCiU2DHhwJELtwLmOlF1eo263Xvdyi8RHEhw4FPwSQAAAABJRU5ErkJggg==);
+  font-size: $icons-size;
 }
 
 span.unpin {
-  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAQAAAD8fJRsAAAAsUlEQVQY02NgQAKqpar/VXwZ0IGKh+p/MMxGFZZVeab6DwTVfqshpFQ5VLer/lf7D5T4rwbEqr4MqlwqhcouauWqEEGgMAiq/mdQCQQKfVb9pQYVhChQaWZQZlddpwbR/g8s+V/1jVos2Hx1NrW1UCGQ9Ck1FYSLWsHO/Kf6V7VLhQ8h7KD6QWWaKlCX6lcVH7iwspLKTuUABgYlNtUtQOPqET6YpqIHYalxqEar8sPEAdj8UUYH1HpBAAAAAElFTkSuQmCC);
+  font-size: $icons-size;
 }
 
 span.enqueue {
-  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAQAAAD8fJRsAAAAoklEQVQY02XQLw6DMBiH4Q+FKeESS0UPMA+uYqS4Db+r9CrIZWZD04wjVMBI3c9PtWZjkn953SNfAq1KbHVx5o1iiRGYy29GhGMw/ZJTq2SrfT2JcHZLLmXHA5+0v7e22jEP0ow5kj13VoGBCARm1YJLpIhAhHjMpNkyiHB4NtpvGUTdSQz1T3vZWjUziPTAP6J/NC4DmxlE168eXgUOiNdz/lSxl2uEe8+QAAAAAElFTkSuQmCC);
+  font-size: $icons-size;
 }
 
 span.dequeue {
-  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAB3RJTUUH4ggOEhs2PtkFxgAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAE5SURBVCjPfZCxSlxhEIW/M/Pf+7uSXddFcEkTSBXClmks7ISgpLBIKSwoAYsEwSLkPdJISJmUpgo+QbBIIalELANuG1ACbvTeSeEim0v0lMOcM+cbACEt49oFetwjd9zBHGyN0AbSQ7ATiPP/7A8knju4QC0sCfkqUT8pLUZVMALAmMXyOlFvRehoYu4WUCyitInSN+FfMZag3QHbQX6A0gqAmjWhHKB4d8MTv7DoQvpANf5yD14aoPwDpUNUvmkkNvRgdp4r3kPVIVSjeIYYQZzeIE1L1uf39UeoH6PYAxuCHYO/xHO/0b7s4nkPyz9R8fZ2PjM/h4rPeH5Fe2HCnHG8tY21zlCxD7nzT5iVT5Hvg/oJgDE9uHoBdgl8QtUFMWWo/xyDf8fj0eRCO6M0BL0G2nd8LpGwv420RBxssgl5AAAAAElFTkSuQmCC);
+  font-size: $icons-size;
 }
 span.auto-enrollment {
-  font-size: 12px;
+  font-size: $icons-size;
 }
 </style>

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -95,7 +95,7 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Odepnij grupę od planu."
           @click="unpin()"
         >
-          <font-awesome-icon icon="thumbtack" transform="right-2" rotation="90"/>
+          <font-awesome-icon icon="thumbtack" transform="left-1 shrink-3" rotation="90"/>
         </span>
         <span
           v-else
@@ -103,7 +103,7 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Przypnij grupę do planu."
           @click="pin()"
         >
-          <font-awesome-icon icon="thumbtack" transform="right-2"/>
+          <font-awesome-icon icon="thumbtack" transform="right-1 shrink-2"/>
         </span>
 
         <span
@@ -145,12 +145,18 @@ export default class TermControlsComponent extends TermControlsProps {
 }
 
 .controls {
-  position: absolute;
   background: white;
+
+  position: relative;
   top: 0;
   left: 0;
+  max-height: 100%;
+
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(auto-fit, 26px);
+
   cursor: default;
-  width: auto;
   border: 1px solid #666666;
   border-top: 0;
   border-left: 0;
@@ -160,33 +166,40 @@ export default class TermControlsComponent extends TermControlsProps {
 }
 
 .controls span {
-  display: block;
-  width: 18px;
-  height: 18px;
-  margin: 3px;
+  padding: 3px;
+  font-size: 20px;
   overflow: hidden;
   cursor: pointer;
 }
-</style>
 
-<style lang="scss">
-$icons-size: 18px;
-span.pin {
-  font-size: $icons-size;
-}
+@media(max-width: 992px) {
+  .controls {
+    background: white;
 
-span.unpin {
-  font-size: $icons-size;
-}
+    position: relative;
+    top: 0;
+    left: 0;
+    max-height: 100%;
+    max-width: 100%;
 
-span.enqueue {
-  font-size: $icons-size;
-}
+    display: inline-flex;
+    flex-direction: row;
+    flex-wrap: wrap;
 
-span.dequeue {
-  font-size: $icons-size;
-}
-span.auto-enrollment {
-  font-size: $icons-size;
+    cursor: default;
+    border: 1px solid #666666;
+    border-top: 0;
+    border-left: 0;
+    border-radius: 4px 0;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
+    z-index: 30;
+  }
+
+  .controls span {
+    padding: 3px;
+    font-size: 28px;
+    overflow: hidden;
+    cursor: pointer;
+  }
 }
 </style>

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -176,33 +176,18 @@ export default class TermControlsComponent extends TermControlsProps {
   cursor: pointer;
 }
 
+// For devices where days are displayed one below another
 @media (max-width: 992px) {
   .controls {
-    background: white;
+    position: relative;
+    max-height: unset;
 
-    position: absolute;
-    top: 0;
-    left: 0;
-    max-height: 100%;
-    max-width: 100%;
-
-    display: inline-grid;
-    grid-auto-flow: row;
-    grid-template-rows: repeat(auto-fit, 33px);
-
-    cursor: default;
-    border: 1px solid #666666;
-    border-top: 0;
-    border-left: 0;
-    border-radius: 4px 0;
-    box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
-    z-index: 30;
+    writing-mode: unset;
+    flex-direction: row;
   }
 
   .controls span {
-    padding: 3px;
     font-size: 30px;
-    cursor: pointer;
   }
 }
 </style>

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -5,16 +5,9 @@
 import Component from "vue-class-component";
 import Vue from "vue";
 import TermComponent from "./Term.vue";
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faCarSide } from "@fortawesome/free-solid-svg-icons/faCarSide";
-import { faThumbtack } from "@fortawesome/free-solid-svg-icons/faThumbtack";
-import { faBan } from "@fortawesome/free-solid-svg-icons/faBan";
-import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 import { Term, Group } from "../models";
-
-library.add(faCarSide, faThumbtack, faBan, faPencilAlt);
 
 const TermControlsProps = Vue.extend({
   props: {
@@ -97,8 +90,8 @@ export default class TermControlsComponent extends TermControlsProps {
         >
           <font-awesome-icon
             icon="thumbtack"
-            transform="left-1 shrink-3"
-            rotation="90"
+            transform="right-1 shrink-3"
+            class="fa-rotate-45"
           />
         </span>
         <span
@@ -107,7 +100,11 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Przypnij grupę do planu."
           @click="pin()"
         >
-          <font-awesome-icon icon="thumbtack" transform="right-1 shrink-2" />
+          <font-awesome-icon
+            icon="thumbtack"
+            transform="right-1 shrink-2"
+            rotation="90"
+          />
         </span>
 
         <span
@@ -176,7 +173,8 @@ export default class TermControlsComponent extends TermControlsProps {
   cursor: pointer;
 }
 
-// For devices where days are displayed one below another
+// For devices with large screens where days are displayed one below another.
+// Bootstrap's convention: https://getbootstrap.com/docs/4.5/layout/overview/#containers
 @media (max-width: 992px) {
   .controls {
     position: relative;
@@ -189,5 +187,15 @@ export default class TermControlsComponent extends TermControlsProps {
   .controls span {
     font-size: 30px;
   }
+}
+</style>
+
+<style lang="scss">
+.fa-rotate-45 {
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  -o-transform: rotate(45deg);
+  transform: rotate(45deg);
 }
 </style>

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -90,8 +90,8 @@ export default class TermControlsComponent extends TermControlsProps {
         >
           <font-awesome-icon
             icon="thumbtack"
-            transform="right-1 shrink-3"
-            class="fa-rotate-45"
+            transform="shrink-1 right-2"
+            class="my-fa-rotate-45 unpin-margin-top"
           />
         </span>
         <span
@@ -102,7 +102,7 @@ export default class TermControlsComponent extends TermControlsProps {
         >
           <font-awesome-icon
             icon="thumbtack"
-            transform="right-1 shrink-2"
+            transform="shrink-1 right-2"
             rotation="90"
           />
         </span>
@@ -113,7 +113,7 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Zapisz do grupy/kolejki."
           @click="enqueue()"
         >
-          <font-awesome-icon icon="pencil-alt" transform="shrink-2" />
+          <font-awesome-icon icon="pencil-alt" transform="shrink-2 right-1" />
         </span>
         <span
           v-if="canDequeue"
@@ -121,14 +121,14 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Wypisz z grupy/kolejki."
           @click="dequeue()"
         >
-          <font-awesome-icon icon="ban" transform="shrink-2" />
+          <font-awesome-icon icon="ban" transform="shrink-1 right-1" />
         </span>
         <span
           v-if="term.group.autoEnrollment"
           class="auto-enrollment"
           title="Grupa z auto-zapisem."
         >
-          <font-awesome-icon icon="car-side" transform="shrink-3 left-2" />
+          <font-awesome-icon icon="car-side" transform="shrink-3 left-1" />
         </span>
       </div>
     </transition>
@@ -149,27 +149,22 @@ export default class TermControlsComponent extends TermControlsProps {
   background: white;
 
   position: absolute;
-  top: 0;
-  left: 0;
-  max-height: 100%;
-
-  display: inline-flex;
-  writing-mode: vertical-lr;
-  flex-wrap: wrap;
-  align-content: flex-start;
+  top: -1px;
+  left: -1px;
 
   cursor: default;
   border: 1px solid #666666;
-  border-top: 0;
-  border-left: 0;
   border-radius: 4px 0;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
   z-index: 30;
 }
 
 .controls span {
-  padding: 3px;
-  font-size: 20px;
+  display: block;
+  margin: 3px;
+  width: 16px;
+  height: 16px;
+  font-size: 14px;
   cursor: pointer;
 }
 
@@ -177,21 +172,30 @@ export default class TermControlsComponent extends TermControlsProps {
 // Bootstrap's convention: https://getbootstrap.com/docs/4.5/layout/overview/#containers
 @media (max-width: 992px) {
   .controls {
-    position: relative;
-    max-height: unset;
+    position: absolute;
+    max-width: 100%;
 
-    writing-mode: unset;
-    flex-direction: row;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, 54px);
+    grid-template-rows: repeat(auto-fit, 47px);
   }
 
   .controls span {
-    font-size: 30px;
+    font-size: 40px;
+    margin: 5px;
+    margin-top: 3px;
+    width: unset;
+    height: unset;
+  }
+
+  .unpin-margin-top {
+    margin-top: 2px;
   }
 }
 </style>
 
 <style lang="scss">
-.fa-rotate-45 {
+.my-fa-rotate-45 {
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
   -ms-transform: rotate(45deg);

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -72,12 +72,15 @@ export default class TermControlsComponent extends TermControlsProps {
     }
   }
 
-  showControls(event: Event) {
+  showControls() {
     this.controlsVisible = true;
     window.addEventListener("touchend", this.hideControls);
   }
 
+  // Hides controls popup whenever there is a "mouseout" event on the Term
+  // component or any touch event outside of it.
   hideControls(event: Event) {
+    // Do not hide controls on touch events inside of the Term.
     if (
       event.type === "touchend" &&
       ((this.$refs.term as Vue).$refs.root as Element).contains(

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -71,14 +71,33 @@ export default class TermControlsComponent extends TermControlsProps {
       this.$store.dispatch("groups/dequeue", this.term.group);
     }
   }
+
+  showControls(event: Event) {
+    this.controlsVisible = true;
+    window.addEventListener("touchend", this.hideControls);
+  }
+
+  hideControls(event: Event) {
+    if (
+      event.type === "touchend" &&
+      ((this.$refs.term as Vue).$refs.root as Element).contains(
+        event.target as Node
+      )
+    ) {
+      return;
+    }
+    this.controlsVisible = false;
+    window.removeEventListener("touchend", this.hideControls);
+  }
 }
 </script>
 
 <template>
   <Term
     :term="term"
-    @mouseover.native="controlsVisible = true"
-    @mouseout.native="controlsVisible = false"
+    @mouseover.native="showControls"
+    @mouseout.native="hideControls"
+    ref="term"
   >
     <transition name="fade">
       <div class="controls" v-if="controlsVisible">
@@ -90,8 +109,8 @@ export default class TermControlsComponent extends TermControlsProps {
         >
           <font-awesome-icon
             icon="thumbtack"
-            transform="shrink-1 right-2"
-            class="my-fa-rotate-45 unpin-margin-top"
+            :transform="{ rotate: 45 }"
+            fixed-width
           />
         </span>
         <span
@@ -100,11 +119,7 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Przypnij grupę do planu."
           @click="pin()"
         >
-          <font-awesome-icon
-            icon="thumbtack"
-            transform="shrink-1 right-2"
-            rotation="90"
-          />
+          <font-awesome-icon icon="thumbtack" rotation="90" fixed-width />
         </span>
 
         <span
@@ -113,7 +128,7 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Zapisz do grupy/kolejki."
           @click="enqueue()"
         >
-          <font-awesome-icon icon="pencil-alt" transform="shrink-2 right-1" />
+          <font-awesome-icon icon="pencil-alt" fixed-width />
         </span>
         <span
           v-if="canDequeue"
@@ -121,14 +136,14 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Wypisz z grupy/kolejki."
           @click="dequeue()"
         >
-          <font-awesome-icon icon="ban" transform="shrink-1 right-1" />
+          <font-awesome-icon icon="ban" fixed-width />
         </span>
         <span
           v-if="term.group.autoEnrollment"
           class="auto-enrollment"
           title="Grupa z auto-zapisem."
         >
-          <font-awesome-icon icon="car-side" transform="shrink-3 left-1" />
+          <font-awesome-icon icon="car-side" fixed-width />
         </span>
       </div>
     </transition>
@@ -157,13 +172,16 @@ export default class TermControlsComponent extends TermControlsProps {
   border-radius: 4px 0;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
   z-index: 30;
+
+  display: flex;
+  flex-direction: column;
 }
 
 .controls span {
   display: block;
-  margin: 3px;
-  width: 16px;
-  height: 16px;
+  padding: 3px;
+  width: 22px;
+  height: 22px;
   font-size: 14px;
   cursor: pointer;
 }
@@ -173,30 +191,41 @@ export default class TermControlsComponent extends TermControlsProps {
 @media (max-width: 992px) {
   .controls {
     position: absolute;
-    min-width: 54px;
-    max-width: 100%;
+    top: -63px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-radius: 4px;
 
-    display: grid;
-    grid-template-columns: repeat(auto-fit, 54px);
-    grid-template-rows: repeat(auto-fit, 47px);
+    min-width: 60px;
+    flex-direction: row;
+
+    // Tooltip arrow.
+    &:before {
+      content: "";
+      display: block;
+      position: absolute;
+      left: calc(50% - 10px);
+      top: 100%;
+      border: 10px solid transparent;
+      border-top-color: black;
+    }
+    &:after {
+      content: "";
+      display: block;
+      position: absolute;
+      left: calc(50% + 1px - 10px);
+      top: 100%;
+      border: 9px solid transparent;
+      border-top-color: white;
+    }
   }
 
   .controls span {
+    display: inline-block;
     font-size: 40px;
-    margin: 5px;
-    margin-top: 3px;
-    width: unset;
-    height: unset;
+    padding: 5px;
+    width: 60px;
+    height: 50px;
   }
-
-  .unpin-margin-top {
-    margin-top: 2px;
-  }
-}
-</style>
-
-<style lang="scss">
-.my-fa-rotate-45 {
-  transform: rotate(45deg);
 }
 </style>

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -5,7 +5,7 @@
 import Component from "vue-class-component";
 import Vue from "vue";
 import TermComponent from "./Term.vue";
-import { library } from '@fortawesome/fontawesome-svg-core'
+import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCarSide } from "@fortawesome/free-solid-svg-icons/faCarSide";
 import { faThumbtack } from "@fortawesome/free-solid-svg-icons/faThumbtack";
 import { faBan } from "@fortawesome/free-solid-svg-icons/faBan";
@@ -95,7 +95,11 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Odepnij grupę od planu."
           @click="unpin()"
         >
-          <font-awesome-icon icon="thumbtack" transform="left-1 shrink-3" rotation="90"/>
+          <font-awesome-icon
+            icon="thumbtack"
+            transform="left-1 shrink-3"
+            rotation="90"
+          />
         </span>
         <span
           v-else
@@ -103,7 +107,7 @@ export default class TermControlsComponent extends TermControlsProps {
           title="Przypnij grupę do planu."
           @click="pin()"
         >
-          <font-awesome-icon icon="thumbtack" transform="right-1 shrink-2"/>
+          <font-awesome-icon icon="thumbtack" transform="right-1 shrink-2" />
         </span>
 
         <span
@@ -172,7 +176,7 @@ export default class TermControlsComponent extends TermControlsProps {
   cursor: pointer;
 }
 
-@media(max-width: 992px) {
+@media (max-width: 992px) {
   .controls {
     background: white;
 

--- a/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/TermControls.vue
@@ -196,10 +196,6 @@ export default class TermControlsComponent extends TermControlsProps {
 
 <style lang="scss">
 .my-fa-rotate-45 {
-  -webkit-transform: rotate(45deg);
-  -moz-transform: rotate(45deg);
-  -ms-transform: rotate(45deg);
-  -o-transform: rotate(45deg);
   transform: rotate(45deg);
 }
 </style>

--- a/zapisy/apps/enrollment/timetable/assets/prototype-legend.scss
+++ b/zapisy/apps/enrollment/timetable/assets/prototype-legend.scss
@@ -5,9 +5,9 @@ ul.schedule-legend {
   list-style: none;
 
   .legend-box {
-    float: left;
-    height: 12px;
-    width: 12px;
+    display: inline-block;
+    height: 18px;
+    width: 18px;
     vertical-align: middle;
     margin-right: 6px;
 

--- a/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
+++ b/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
@@ -45,14 +45,19 @@
         <ul class="schedule-legend">
             <li>
                 <span class="legend-box">
-                    <i class="fa fa-thumbtack"></i>
+                    <i class="fa fa-thumbtack fa-rotate-90"></i>
                 </span> — Przypina do prototypu.
                 Widoczność grupy w prototypie zostaje zapamiętana. Przycisk
                 <strong>nie zapisuje</strong> na zajęcia.
             </li>
             <li>
                 <span class="legend-box">
-                    <i class="fa fa-thumbtack fa-rotate-90"></i>
+                    <i class="fa fa-thumbtack" style="
+                      -webkit-transform: rotate(45deg);
+                      -moz-transform: rotate(45deg);
+                      -ms-transform: rotate(45deg);
+                      -o-transform: rotate(45deg);
+                      transform: rotate(45deg);"></i>
                 </span> — Odpina od prototypu.
                 Przywraca domyślną widoczność grupy w prototypie. Przycisk
                 <strong>nie wypisuje</strong> z zajęć.

--- a/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
+++ b/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
@@ -45,21 +45,21 @@
         <ul class="schedule-legend">
             <li>
                 <span class="legend-box">
-                    <i class="fa fa-thumbtack fa-rotate-90"></i>
+                    <i class="fa fa-thumbtack fa-rotate-90 fa-fw"></i>
                 </span> — Przypina do prototypu.
                 Widoczność grupy w prototypie zostaje zapamiętana. Przycisk
                 <strong>nie zapisuje</strong> na zajęcia.
             </li>
             <li>
                 <span class="legend-box">
-                    <i class="fa fa-thumbtack my-fa-rotate-45"></i>
+                    <i class="fa fa-thumbtack fa-fw" data-fa-transform="rotate-45"></i>
                 </span> — Odpina od prototypu.
                 Przywraca domyślną widoczność grupy w prototypie. Przycisk
                 <strong>nie wypisuje</strong> z zajęć.
             </li>
             <li>
                 <span class="legend-box">
-                    <i class="fa fa-pencil-alt"></i>
+                    <i class="fa fa-pencil-alt fa-fw"></i>
                 </span> — Zapisuje do kolejki.
                 Jak tylko w grupie będzie wolne miejsce (być może natychmiast),
                 studenci z przodu kolejki zostaną do niej wciągnięci przez
@@ -67,13 +67,13 @@
             </li>
             <li>
                 <span class="legend-box">
-                    <i class="fa fa-ban"></i>
+                    <i class="fa fa-ban fa-fw"></i>
                 </span> — Wypisuje z grupy lub
                 jej kolejki.
             </li>
             <li>
                 <span class="legend-box">
-                    <i class="fa fa-car-side" data-fa-transform="shrink-3 left-2"></i>
+                    <i class="fa fa-car-side fa-fw"></i>
                 </span> — Grupa z auto-zapisem. Stan tej grupy jest automatycznie synchronizowany z
                 innymi grupami tego przedmiotu. Zapisz się do innych grup, a automatycznie się w niej
                 znajdziesz.

--- a/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
+++ b/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
@@ -52,12 +52,7 @@
             </li>
             <li>
                 <span class="legend-box">
-                    <i class="fa fa-thumbtack" style="
-                      -webkit-transform: rotate(45deg);
-                      -moz-transform: rotate(45deg);
-                      -ms-transform: rotate(45deg);
-                      -o-transform: rotate(45deg);
-                      transform: rotate(45deg);"></i>
+                    <i class="fa fa-thumbtack my-fa-rotate-45"></i>
                 </span> — Odpina od prototypu.
                 Przywraca domyślną widoczność grupy w prototypie. Przycisk
                 <strong>nie wypisuje</strong> z zajęć.

--- a/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
+++ b/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
@@ -44,27 +44,35 @@
         </ul>
         <ul class="schedule-legend">
             <li>
-                <span class="legend-box pin"></span> — Przypina do prototypu.
+                <span class="legend-box">
+                    <i class="fa fa-thumbtack"></i>
+                </span> — Przypina do prototypu.
                 Widoczność grupy w prototypie zostaje zapamiętana. Przycisk
                 <strong>nie zapisuje</strong> na zajęcia.
             </li>
             <li>
-                <span class="legend-box unpin"></span> — Odpina od prototypu.
+                <span class="legend-box">
+                    <i class="fa fa-thumbtack fa-rotate-90"></i>
+                </span> — Odpina od prototypu.
                 Przywraca domyślną widoczność grupy w prototypie. Przycisk
                 <strong>nie wypisuje</strong> z zajęć.
             </li>
             <li>
-                <span class="legend-box enqueue"></span> — Zapisuje do kolejki.
+                <span class="legend-box">
+                    <i class="fa fa-pencil-alt"></i>
+                </span> — Zapisuje do kolejki.
                 Jak tylko w grupie będzie wolne miejsce (być może natychmiast),
                 studenci z przodu kolejki zostaną do niej wciągnięci przez
                 asynchroniczny proces.
             </li>
             <li>
-                <span class="legend-box dequeue"></span> — Wypisuje z grupy lub
+                <span class="legend-box">
+                    <i class="fa fa-ban"></i>
+                </span> — Wypisuje z grupy lub
                 jej kolejki.
             </li>
             <li>
-                <span class="legend-box auto-enrollment">
+                <span class="legend-box">
                     <i class="fa fa-car-side" data-fa-transform="shrink-3 left-2"></i>
                 </span> — Grupa z auto-zapisem. Stan tej grupy jest automatycznie synchronizowany z
                 innymi grupami tego przedmiotu. Zapisz się do innych grup, a automatycznie się w niej


### PR DESCRIPTION
Zwiększamy przydatność prototypu planu na małych ekranach. Jego główną wadą były zbyt małe przyciski do podejmowania akcji (przypinanie, zapisywanie).

Zmiana składa się z trzech elementów:
1. Zamiana starych ikon, które były grafikami 12x12 pikseli, na ikony z Font Awesome.
2. Różny sposób wyświetlania ich na dużych i małych ekranach.
3. Poprawione rozpoznawanie, że należy schować przyciski (rozpoznawanie, że Term stracił focus na ekranach dotykowych).

Fixes #967 

|              Obecnie               |         Po zmianach          |
|:----------------------------------:|:-------------------------------:|
| ![image](https://user-images.githubusercontent.com/5896456/107148538-fe9f8000-6953-11eb-9413-08c44cbe74f2.png)  |  ![image](https://user-images.githubusercontent.com/5896456/107148503-c009c580-6953-11eb-8a5d-a3e81d880c09.png) |
| ![image](https://user-images.githubusercontent.com/5896456/107148592-563deb80-6954-11eb-9fbb-bc8783c2073a.png) | ![image](https://user-images.githubusercontent.com/5896456/107148623-90a78880-6954-11eb-923e-d2a9301ebafb.png) |
