### PR TITLE
Konfiguracja raportowania do Rollbara

### DIFF
--- a/infra/playbooks/templates/env.j2
+++ b/infra/playbooks/templates/env.j2
@@ -37,5 +37,8 @@ GDRIVE_TOKEN_URI=https://oauth2.googleapis.com/token
 GDRIVE_AUTH_PROVIDER=https://www.googleapis.com/oauth2/v1/certs
 GDRIVE_CLIENT_CERT_URL={{ gdrive_client_cert_url }}
 
-ROLLBAR=access_token={{ rollbar_token }},environment={{ deploy_env }},branch={{ deploy_version }},root=/home/{{ deploy_user }}/deploy/current/zapisy/
+ROLLBAR_TOKEN={{ rollbar_token }}
+ROLLBAR_ENV={{ deploy_env }}
+ROLLBAR_BRANCH={{ deploy_version }}
+
 ARRAY_VALS={"ADMINS": [["System Zapisow", "zapisy@cs.uni.wroc.pl"]]}

--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -3,6 +3,7 @@ import os
 import environ
 from django.contrib.messages import constants as messages
 from django.core.exceptions import PermissionDenied
+from django.http import Http404
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -323,7 +324,8 @@ ROLLBAR = {
     'branch': env.str('ROLLBAR_BRANCH', default=''),
     'root': BASE_DIR,
     'exception_level_filters': [
-        (PermissionDenied, 'ignore')
+        (PermissionDenied, 'warning'),
+        (Http404, 'warning')
     ]
 }
 

--- a/zapisy/zapisy/settings.py
+++ b/zapisy/zapisy/settings.py
@@ -2,6 +2,7 @@ import os
 
 import environ
 from django.contrib.messages import constants as messages
+from django.core.exceptions import PermissionDenied
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -316,7 +317,15 @@ SECURE_HSTS_PRELOAD = True
 DEBUG_TOOLBAR_ALLOWED_USERS = env.list('DEBUG_TOOLBAR_ALLOWED_USERS', default=[])
 DEBUG_TOOLBAR_PANELS = env.list('DEBUG_TOOLBAR_PANELS', default=[])
 
-ROLLBAR = env.dict('ROLLBAR', default={})
+ROLLBAR = {
+    'access_token': env.str('ROLLBAR_TOKEN', default=''),
+    'environment': env.str('ROLLBAR_ENV', default=''),
+    'branch': env.str('ROLLBAR_BRANCH', default=''),
+    'root': BASE_DIR,
+    'exception_level_filters': [
+        (PermissionDenied, 'ignore')
+    ]
+}
 
 # Message classes set to be compatible with Bootstrap 4 alerts.
 MESSAGE_TAGS = {


### PR DESCRIPTION
Dzięki skonfigurowaniu 'exception_level_filters' Rollbar będzie ignorować wyjątki PermissionDenied - gdy jakiś użytkownik chciał uzyskać dostęp do zasobu, do którego nie ma uprawnień - Rollbar nie będzie już raportować tych wyjątków jako błędów.

Konfiguracja Rollbara została przeniesiona do settings.py, aby całość znajdowała się w jednym miejscu, a w pliku .env zostały tylko potrzebne do konfiguracji wpisy z przedrostkiem ROLLBAR_.

Fixes #976 