### PR TITLE
Naprawia API dla prototypu.

### DIFF
--- a/zapisy/apps/enrollment/timetable/assets/store/groups.ts
+++ b/zapisy/apps/enrollment/timetable/assets/store/groups.ts
@@ -140,9 +140,8 @@ const actions = {
       .post(group.actionURL, {
         action: "enqueue",
       })
-      .then((response) => {
-        const groupsJSON = response.data as GroupJSON[];
-        groupsJSON.forEach((groupJSON) => commit("updateGroup", { groupJSON }));
+      .then((_) => {
+        commit("setEnqueued", { g: group.id });
       })
       .catch((reason) => {
         console.log("Enqueuing failed: ", reason);
@@ -155,12 +154,9 @@ const actions = {
       .post(group.actionURL, {
         action: "dequeue",
       })
-      .then((response) => {
-        const groupIDs = response.data as number[];
-        groupIDs.forEach((g) => {
-          commit("unsetEnrolled", { g });
-          commit("unsetEnqueued", { g });
-        });
+      .then((_) => {
+        commit("unsetEnrolled", { g: group.id });
+        commit("unsetEnqueued", { g: group.id });
       })
       .catch((reason) => {
         console.log("Dequeuing failed: ", reason);

--- a/zapisy/apps/enrollment/timetable/views.py
+++ b/zapisy/apps/enrollment/timetable/views.py
@@ -210,21 +210,12 @@ def prototype_action(request, group_id):
         success = Record.enqueue_student(student, group)
         if not success:
             return HttpResponse(status=403)
-        # When the student joins the queue of a class, the accompanying lecture
-        # group might need to be displayed (if he is automatically enqueued in
-        # that). We hence send him the information about these groups.
-        groups = Group.objects.filter(course=group.course_id).select_related(
-            'teacher', 'teacher__user', 'course', 'course__semester').prefetch_related(
-                'term', 'term__classrooms', 'guaranteed_spots', 'guaranteed_spots__role')
-        groups = Record.is_recorded_in_groups(student, groups)
-        groups_dicts = build_group_list(groups)
-        return JsonResponse(groups_dicts, safe=False)
+        return HttpResponse(status=204)
     if action == 'dequeue':
-        group_ids = Record.remove_from_group(student, group)
-        if group_ids:
-            return JsonResponse(group_ids, safe=False)
-        else:
+        success = Record.remove_from_group(student, group)
+        if not success:
             return HttpResponse(status=403)
+        return HttpResponse(status=204)
     # If the request action is not among the above, we return Bad Request
     # response.
     return HttpResponse(status=400, content=action)


### PR DESCRIPTION
Po wprowadzeniu grup „auto” zapisywanie i wypisywanie z grup zajęciowych stało się bardziej atomowe: Zapisanie do grupy ćwiczeniowej nie pociąga już za sobą automatycznego, synchronicznego zapisania na wykład, bo zajmuje się tym asynchroniczny proces. Uprościło to funkcje w pliku records.py, ale zapomniałem poprawić API dla prototypu. Teraz nadrabiam tę zaległość.

Prototyp nie dostaje już po zakolejkowaniu/wypisaniu listy grup do uaktualnienia. Uaktualnia tę jedną grupę, której dotyczyła akcja, a reszta grup uaktualni się asynchronicznie.