### PR TITLE
Updates to theses application

### DIFF
--- a/zapisy/apps/theses/__init__.py
+++ b/zapisy/apps/theses/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'apps.theses.apps.ThesesConfig'

--- a/zapisy/apps/theses/apps.py
+++ b/zapisy/apps/theses/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class ThesesConfig(AppConfig):
+    name = 'apps.theses'
+    verbose_name = 'Theses'
+
+    def ready(self):
+        from . import signals  # noqa

--- a/zapisy/apps/theses/assets/components/ThesisFilter.vue
+++ b/zapisy/apps/theses/assets/components/ThesisFilter.vue
@@ -61,7 +61,6 @@ export default Vue.extend({
             filterKey="status-filter"
             property="status"
             :options="allStatuses"
-            default="zaakceptowana"
             placeholder="Status pracy dyplomowej"
           />
         </div>

--- a/zapisy/apps/theses/forms.py
+++ b/zapisy/apps/theses/forms.py
@@ -7,7 +7,6 @@ from apps.common import widgets as common_widgets
 from apps.theses.enums import ThesisKind, ThesisStatus, ThesisVote
 from apps.theses.models import (MAX_ASSIGNED_STUDENTS, MAX_ASSIGNED_STUDENTS_WITH_PERM, MAX_THESIS_TITLE_LEN, Remark,
                                 Thesis, Vote)
-from apps.theses.system_settings import change_status
 from apps.users.models import Employee, Student
 
 
@@ -283,14 +282,8 @@ class VoteForm(forms.ModelForm):
             instance.owner = self.user.employee
         if getattr(instance, 'thesis', None) is None:
             instance.thesis = self.thesis
-        thesis = instance.thesis
-
-        # check number of votes and change thesis status
-        change_status(thesis, instance.vote)
-
         if commit:
             instance.save()
-
         return instance
 
 

--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -11,7 +11,8 @@ from apps.users.models import Employee, Student
 
 MAX_THESIS_TITLE_LEN = 300
 MAX_REJECTION_REASON_LENGTH = 500
-MAX_ASSIGNED_STUDENTS = 2
+MAX_ASSIGNED_STUDENTS = 1
+MAX_ASSIGNED_STUDENTS_WITH_PERM = 3
 
 
 class ThesesSystemSettings(models.Model):
@@ -96,6 +97,9 @@ class Thesis(models.Model):
     class Meta:
         verbose_name = "praca dyplomowa"
         verbose_name_plural = "prace dyplomowe"
+        permissions = [
+            ("assign_multiple_students", "Can assign a thesis to more than one student")
+        ]
 
     def save(self, *args, **kwargs):
         """Overloaded save method.

--- a/zapisy/apps/theses/signals.py
+++ b/zapisy/apps/theses/signals.py
@@ -1,0 +1,20 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .enums import ThesisVote, ThesisStatus
+from .models import Vote
+from .system_settings import get_num_required_votes
+
+
+@receiver(post_save, sender=Vote)
+def auto_accept(sender, instance: Vote, **kwargs):
+    """Accepts thesis when enough accepting votes have been submitted."""
+    thesis = instance.thesis
+    vote = instance.vote
+
+    if vote == ThesisVote.ACCEPTED and thesis.get_accepted_votes() >= get_num_required_votes():
+        if thesis.has_no_students_assigned:
+            thesis.status = ThesisStatus.ACCEPTED
+        else:
+            thesis.status = ThesisStatus.IN_PROGRESS
+        thesis.save()

--- a/zapisy/apps/theses/system_settings.py
+++ b/zapisy/apps/theses/system_settings.py
@@ -3,8 +3,6 @@
 The functions in this module permit interaction with the theses system settings
 implemented as a single instance of models.ThesesSystemSettings.
 """
-from apps.theses.enums import ThesisStatus, ThesisVote
-
 from . import models
 
 
@@ -23,17 +21,3 @@ def get_num_required_votes():
 def get_master_rejecter():
     """Get the special board member responsible for rejecting theses."""
     return _get_settings().master_rejecter
-
-
-def change_status(thesis, vote):
-    """Implements status changes.
-
-    Status changes automatically of a thesis depending on previous votes, new
-    vote and assigned students.
-    """
-    if vote == ThesisVote.ACCEPTED and thesis.get_accepted_votes() >= get_num_required_votes() - 1:
-        if thesis.has_no_students_assigned:
-            thesis.status = ThesisStatus.ACCEPTED
-        else:
-            thesis.status = ThesisStatus.IN_PROGRESS
-        thesis.save()

--- a/zapisy/apps/theses/tests/test_status.py
+++ b/zapisy/apps/theses/tests/test_status.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 from apps.theses.enums import ThesisStatus, ThesisVote
 from apps.theses.forms import EditThesisForm
 from apps.theses.models import ThesesSystemSettings, Thesis, Vote
-from apps.theses.system_settings import change_status
 from apps.users.tests.factories import EmployeeFactory, StudentFactory
 
 
@@ -46,8 +45,8 @@ class ThesisStatusChangeTestCase(TestCase):
         vote_1 = Vote.objects.create(owner=EmployeeFactory(),
                                      vote=ThesisVote.ACCEPTED, thesis=thesis_vote_1)
 
-        change_status(thesis_vote_0, vote_0.vote)
-        change_status(thesis_vote_1, vote_1.vote)
+        vote_0.save()
+        vote_1.save()
 
         self.assertEqual(thesis_vote_0.status, ThesisStatus.ACCEPTED)
         self.assertEqual(thesis_vote_1.status, ThesisStatus.IN_PROGRESS)


### PR DESCRIPTION
#### Changes limits of students assigned to a thesis.
- Regular employees may assign only one student
- Users with permission may assign up to three students
- The check is only triggered when students assignment changes
#### Status filter is not selected by default
#### Thesis should no longer be accepted by accidental double vote
- Auto accept triggers on accepting vote being saved
- Thesis is set to accepted when there are enough positive votes in total (including the one which caused trigger)
