### PR TITLE
Poprawki infrastrukturalne

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb|
     # Customize the amount of memory on the VM:
-    vb.memory = "2048"
+    vb.memory = "4096"
     vb.cpus = "2"
     # Enable "IO APIC" for better multicore performance, see
     # https://serverfault.com/questions/74672/why-should-i-enable-io-apic-in-virtualbox

--- a/infra/hosts/Vagrantfile
+++ b/infra/hosts/Vagrantfile
@@ -13,6 +13,6 @@ Vagrant.configure("2") do |config|
     vb.customize [ "modifyvm", :id, "--uartmode1", "file", File::NULL ]
 
     # Customize the amount of memory on the VM:
-    vb.memory = "2048"
+    vb.memory = "4096"
   end
 end

--- a/infra/playbooks/deploy.yml
+++ b/infra/playbooks/deploy.yml
@@ -43,6 +43,15 @@
         path: "{{ deploy_helper.new_release_path }}/infra/db_backups/perform_dump.sh"
         mode: '0774'
 
+    - name: Upgrade pip
+      become: yes
+      become_user: "{{ deploy_user }}"
+      pip:
+        name: pip
+        state: latest
+        virtualenv: "{{ deploy_helper.new_release_path }}/venv"
+        virtualenv_command: "{{ ansible_python_interpreter }} -m venv"
+
     - name: Set up virtualenv and get requirements
       become: yes
       become_user: "{{ deploy_user }}"

--- a/infra/playbooks/dev/playbook.yml
+++ b/infra/playbooks/dev/playbook.yml
@@ -41,6 +41,15 @@
         insertafter: EOF
         create: yes
 
+    - name: Upgrade pip
+      vars:
+        ansible_python_interpreter: "{{ PYTHON }}"
+      pip:
+        name: pip
+        state: latest
+        virtualenv: ~/env3
+        virtualenv_command: "{{ PYTHON }} -m venv"
+
     - name: Set up virtualenv and get requirements
       vars:
         ansible_python_interpreter: "{{ PYTHON }}"


### PR DESCRIPTION
- Dodaje krok do playbooków w którym `pip` jest aktualizowany do najnowszej wersji. Wersja dostępna w repozytorium miała stary algorytm rezolucji zależności który nie respektował więzów wymaganych przez pakiety.

- Zwiększa domyślny rozmiar pamięci w maszynach wirtulanych do 4GB.