### PR TITLE
Trwałe filtry rodzaju SelectFilter

### DIFF
--- a/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
@@ -35,7 +35,11 @@ export default Vue.extend({
   },
   created: function() {
     const searchParams = new URL(window.location.href).searchParams;
-    if(searchParams.has(this.filterKey)) {
+    const isChosenKey = ([key, _]) => searchParams.get(this.filterKey) == key;
+
+    if(searchParams.has(this.filterKey) && this.options.some(isChosenKey)) {
+      // Set selection from URL only if respective key is in search params
+      // and its value is a valid option.
       this.$data.selected = searchParams.get(this.filterKey);
     }
   },

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
@@ -35,7 +35,8 @@ export default Vue.extend({
   },
   created: function () {
     const searchParams = new URL(window.location.href).searchParams;
-    const isChosenKey = ([key, _]) => searchParams.get(this.filterKey) == key;
+    const isChosenKey = ([key, _]: [number, string]) =>
+      searchParams.get(this.filterKey) == key.toString();
 
     if (searchParams.has(this.filterKey) && this.options.some(isChosenKey)) {
       // Set selection from URL only if respective key is in search params
@@ -54,7 +55,7 @@ export default Vue.extend({
       } else {
         url.searchParams.set(this.filterKey, newSelected.toString());
       }
-      window.history.replaceState(null, null, url);
+      window.history.replaceState(null, "", url.toString());
 
       this.registerFilter({
         k: this.filterKey,

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
@@ -33,11 +33,11 @@ export default Vue.extend({
       selected: undefined,
     };
   },
-  created: function() {
+  created: function () {
     const searchParams = new URL(window.location.href).searchParams;
     const isChosenKey = ([key, _]) => searchParams.get(this.filterKey) == key;
 
-    if(searchParams.has(this.filterKey) && this.options.some(isChosenKey)) {
+    if (searchParams.has(this.filterKey) && this.options.some(isChosenKey)) {
       // Set selection from URL only if respective key is in search params
       // and its value is a valid option.
       this.$data.selected = searchParams.get(this.filterKey);

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
@@ -36,12 +36,12 @@ export default Vue.extend({
   created: function () {
     const searchParams = new URL(window.location.href).searchParams;
     const isChosenKey = ([key, _]: [number, string]) =>
-      searchParams.get(this.filterKey) == key.toString();
+      searchParams.get(this.property) == key.toString();
 
-    if (searchParams.has(this.filterKey) && this.options.some(isChosenKey)) {
+    if (searchParams.has(this.property) && this.options.some(isChosenKey)) {
       // Set selection from URL only if respective key is in search params
       // and its value is a valid option.
-      this.$data.selected = searchParams.get(this.filterKey);
+      this.$data.selected = searchParams.get(this.property);
     }
   },
   methods: {
@@ -51,9 +51,9 @@ export default Vue.extend({
     selected: function (newSelected: string | undefined) {
       const url = new URL(window.location.href);
       if (isUndefined(newSelected)) {
-        url.searchParams.delete(this.filterKey);
+        url.searchParams.delete(this.property);
       } else {
-        url.searchParams.set(this.filterKey, newSelected.toString());
+        url.searchParams.set(this.property, newSelected.toString());
       }
       window.history.replaceState(null, "", url.toString());
 


### PR DESCRIPTION
Rozszerzenie zachowania rozwijanych list (dropdowns) o synchronizację wartości z parametrami zapytania w URLu.

Przy inicjalizacji filtra sprawdza on parametry zapytania URL i jeśli znajdzie pasujący wpis ustali swoją wartość jeśli ta w URLu pochodzi z listy prawidłowych wartości. Przy zmianie wartości filtra, zostanie ona odwzorowana w URLu.

Listy rozwijane są obecne także w module prac dyplomowych. Tamten moduł zwiera własne kopie definicji `(Select|Check|Text)Filter`, możliwe że warto byłoby kiedyś połączyć definicje w obu modułach żeby zmniejszyć duplikację kodu.

---

Ten PR jest częścią implementacji trwałych filtrów (patrz https://github.com/iiuni/projektzapisy/issues/1024). Całość zmian w ramach zadania jest agregowana w PRze (TODO).