### PR TITLE
Zachowywanie filtrów przy zmianie semestru na stronie Przedmioty

### DIFF
--- a/zapisy/apps/enrollment/courses/assets/components/CourseList.vue
+++ b/zapisy/apps/enrollment/courses/assets/components/CourseList.vue
@@ -24,15 +24,35 @@ export default Vue.extend({
     this.courses = courseData;
     this.visibleCourses = courseData;
 
+    // Append the initial query string to links in the semester dropdown.
+    updateSemesterLinks();
+
     this.$store.subscribe((mutation, _) => {
       switch (mutation.type) {
         case "filters/registerFilter":
           this.visibleCourses = this.courses.filter(this.tester);
+          // Update the query string of links in the semester dropdown
+          // to reflect the new state of filters.
+          updateSemesterLinks();
           break;
       }
     });
   },
 });
+
+// Replaces the query string of links in the semester dropdown with the current query string.
+function updateSemesterLinks() {
+  const queryString = window.location.search;
+  const semesterLinks = document.getElementsByClassName("semester-link");
+  for (let i = 0; i < semesterLinks.length; i++) {
+    const link: Element = semesterLinks[i];
+    const hrefValue = link.getAttribute("href");
+    if (hrefValue !== null) {
+      const semesterPath = hrefValue.split("?")[0];
+      link.setAttribute("href", semesterPath + queryString);
+    }
+  }
+}
 </script>
 
 <template>

--- a/zapisy/apps/enrollment/courses/templates/courses/base.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/base.html
@@ -15,10 +15,7 @@
             
             <div class="dropdown-menu" aria-labelledby="semester-dropdown">
                 {% for semester in all_semesters %}
-                    <a class="dropdown-item"
-                       onclick="window.location.href=`{% url 'courses-semester' semester.pk %}`+window.location.search">
-                        {{ semester }}
-                    </a>
+                <a class="dropdown-item semester-link" href={% url 'courses-semester' semester.pk %}>{{ semester }}</a>
                 {% endfor %}
             </div>
         </div>

--- a/zapisy/apps/enrollment/courses/templates/courses/base.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/base.html
@@ -15,7 +15,10 @@
             
             <div class="dropdown-menu" aria-labelledby="semester-dropdown">
                 {% for semester in all_semesters %}
-                <a class="dropdown-item" href={% url 'courses-semester' semester.pk %}>{{ semester }}</a>
+                    <a class="dropdown-item"
+                       onclick="window.location.href=`{% url 'courses-semester' semester.pk %}`+window.location.search">
+                        {{ semester }}
+                    </a>
                 {% endfor %}
             </div>
         </div>


### PR DESCRIPTION
Odnośniki w dropdown-menu z wyborem semestrów zostały zmodyfikowane tak, aby przejście na stronę wybranego semestru zachowywało parametry GET w URLu, w których zapisany jest stan filtrów.