### PR TITLE
Trwałe filtry rodzaju CheckFilter

### DIFF
--- a/zapisy/apps/enrollment/timetable/assets/components/filters/CheckFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/CheckFilter.vue
@@ -32,11 +32,35 @@ export default Vue.extend({
       on: false,
     };
   },
+  created: function () {
+    const searchParams = new URL(window.location.href).searchParams;
+
+    if (searchParams.has(this.property)) {
+      // Set `on` from URL only if respective key is in search params...
+      if (searchParams.get(this.property) === "true") {
+        // and it's value is `true`.
+        this.$data.on = true;
+      } else {
+        // otherwise prune value from search params.
+        const url = new URL(window.location.href);
+        url.searchParams.delete(this.property);
+        window.history.replaceState(null, "", url.toString());
+      }
+    }
+  },
   methods: {
     ...mapMutations("filters", ["registerFilter"]),
   },
   watch: {
     on: function (newOn: boolean) {
+      const url = new URL(window.location.href);
+      if (newOn) {
+        url.searchParams.set(this.property, newOn.toString());
+      } else {
+        url.searchParams.delete(this.property);
+      }
+      window.history.replaceState(null, "", url.toString());
+
       this.registerFilter({
         k: this.filterKey,
         f: new BooleanFilter(newOn, this.property),

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/CheckFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/CheckFilter.vue
@@ -40,11 +40,6 @@ export default Vue.extend({
       if (searchParams.get(this.property) === "true") {
         // and it's value is `true`.
         this.$data.on = true;
-      } else {
-        // otherwise prune value from search params.
-        const url = new URL(window.location.href);
-        url.searchParams.delete(this.property);
-        window.history.replaceState(null, "", url.toString());
       }
     }
   },


### PR DESCRIPTION
Rozszerzenie zachowania checkboxów o synchronizację wartości z parametrami zapytania w URLu.

Przy inicjalizacji filtra, sprawdza on parametry zapytania URL i jeśli znajdzie pasujący wpis z wartością `"true"`, ustali swoją wartość. Przy zmianie wartości filtra, zostanie ona odwzorowana w URLu, chyba że wartość jest fałszywa - w takim przypadku wpis w URLu zostanie usunięty.

---

Ten PR jest częścią implementacji trwałych filtrów (patrz https://github.com/iiuni/projektzapisy/issues/1024). Całość zmian w ramach zadania jest agregowana w PRze https://github.com/iiuni/projektzapisy/pull/1129.