### PR TITLE
Trwałe filtry rodzaju TextFilter

### DIFF
--- a/zapisy/apps/enrollment/timetable/assets/components/filters/TextFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/TextFilter.vue
@@ -32,11 +32,27 @@ export default Vue.extend({
       pattern: "",
     };
   },
+  created: function () {
+    const searchParams = new URL(window.location.href).searchParams;
+
+    if (searchParams.has(this.property)) {
+      // Set `pattern` from URL only if respective key is in search params.
+      this.$data.pattern = searchParams.get(this.property);
+    }
+  },
   methods: {
     ...mapMutations("filters", ["registerFilter"]),
   },
   watch: {
     pattern: function (newPattern: string, _) {
+      const url = new URL(window.location.href);
+      if (newPattern.length == 0) {
+        url.searchParams.delete(this.property);
+      } else {
+        url.searchParams.set(this.property, newPattern);
+      }
+      window.history.replaceState(null, "", url.toString());
+
       this.registerFilter({
         k: this.filterKey,
         f: new TextFilter(newPattern, this.property),


### PR DESCRIPTION
Rozszerzenie zachowania pól tekstowych o synchronizację wartości z parametrami zapytania w URLu.

Przy inicjalizacji filtra, sprawdza on parametry zapytania URL i jeśli znajdzie pasujący wpis ustali swoją wartość. Przy zmianie wartości filtra, zostanie ona odwzorowana w URLu, chyba że wartość jest pustym tekstem - w takim przypadku wpis w URLu zostanie usunięty.

---

Ten PR jest częścią implementacji trwałych filtrów (patrz https://github.com/iiuni/projektzapisy/issues/1024). Całość zmian w ramach zadania jest agregowana w PRze https://github.com/iiuni/projektzapisy/pull/1129.