### PR TITLE
Automatyczne rozwijanie menu z filtrami

### DIFF
--- a/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
@@ -38,6 +38,20 @@ export default Vue.extend({
       return [Number(k), `${a} ${b}`] as [number, string];
     });
     this.allTypes = toPairs(filtersData.allTypes);
+
+    const filterableProperties = [
+      "name",
+      "tags",
+      "courseType",
+      "effects",
+      "owner",
+      "recommendedForFirstYear",
+    ];
+    const searchParams = new URL(window.location.href).searchParams;
+    // Expand the filters if there are any initially specified in the search params
+    if (filterableProperties.some((p: string) => searchParams.has(p))) {
+      this.collapsed = false;
+    }
   },
 });
 </script>

--- a/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
@@ -48,7 +48,7 @@ export default Vue.extend({
       "recommendedForFirstYear",
     ];
     const searchParams = new URL(window.location.href).searchParams;
-    // Expand the filters if there are any initially specified in the search params
+    // Expand the filters if there are any initially specified in the search params.
     if (filterableProperties.some((p: string) => searchParams.has(p))) {
       this.collapsed = false;
     }

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/LabelsFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/LabelsFilter.vue
@@ -59,9 +59,7 @@ export default Vue.extend({
       } else {
         url.searchParams.delete(this.property);
       }
-      url.search = window.decodeURIComponent(url.search); // Commas are ill-handled by URL/URLSearchParams class
-      const urlStr = url.toString();
-      window.history.replaceState(null, "", urlStr);
+      window.history.replaceState(null, "", url.toString());
 
       this.registerFilter({
         k: this.filterKey,

--- a/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
+++ b/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
@@ -50,6 +50,22 @@ export default Vue.extend({
       ["IN_VOTE", "poddany pod głosowanie"],
       ["WITHDRAWN", "wycofany z oferty"],
     ];
+
+    const filterableProperties = [
+      "name",
+      "tags",
+      "courseType",
+      "effects",
+      "owner",
+      "recommendedForFirstYear",
+      "semester",
+      "status",
+    ];
+    const searchParams = new URL(window.location.href).searchParams;
+    // Expand the filters if there are any initially specified in the search params
+    if (filterableProperties.some((p: string) => searchParams.has(p))) {
+      this.collapsed = false;
+    }
   },
 });
 </script>

--- a/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
+++ b/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
@@ -62,7 +62,7 @@ export default Vue.extend({
       "status",
     ];
     const searchParams = new URL(window.location.href).searchParams;
-    // Expand the filters if there are any initially specified in the search params
+    // Expand the filters if there are any initially specified in the search params.
     if (filterableProperties.some((p: string) => searchParams.has(p))) {
       this.collapsed = false;
     }


### PR DESCRIPTION
Jeśli w URLu występują parametry filtrowania, to po załadowaniu strony menu z filtrami będzie rozwinięte.

Jest tutaj zawarta także modyfikacja zmian wprowadzonych w ramach #1123, polegająca na wycofaniu się z dekodowania query stringa.  

---

Ten PR jest częścią implementacji trwałych filtrów (patrz https://github.com/iiuni/projektzapisy/issues/1024). Całość zmian w ramach zadania jest agregowana w PRze https://github.com/iiuni/projektzapisy/pull/1129.