### PR TITLE
Nowy guzik służący resetowaniu stanu filtrów przedmiotów

### DIFF
--- a/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
@@ -7,6 +7,7 @@ import LabelsFilter from "./filters/LabelsFilter.vue";
 import SelectFilter from "./filters/SelectFilter.vue";
 import CheckFilter from "./filters/CheckFilter.vue";
 import { FilterDataJSON } from "./../models";
+import { mapMutations } from "vuex";
 
 export default Vue.extend({
   components: {
@@ -52,6 +53,9 @@ export default Vue.extend({
     if (filterableProperties.some((p: string) => searchParams.has(p))) {
       this.collapsed = false;
     }
+  },
+  methods: {
+    ...mapMutations("filters", ["clearFilters"]),
   },
 });
 </script>
@@ -104,6 +108,14 @@ export default Vue.extend({
             property="recommendedForFirstYear"
             label="Pokaż tylko przedmioty zalecane dla pierwszego roku"
           />
+          <hr />
+          <button
+            class="btn btn-outline-secondary"
+            type="button"
+            @click="clearFilters()"
+          >
+            Wyczyść filtry
+          </button>
         </div>
       </div>
     </div>

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/CheckFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/CheckFilter.vue
@@ -36,9 +36,7 @@ export default Vue.extend({
     const searchParams = new URL(window.location.href).searchParams;
 
     if (searchParams.has(this.property)) {
-      // Set `on` from URL only if respective key is in search params...
       if (searchParams.get(this.property) === "true") {
-        // and it's value is `true`.
         this.on = true;
       }
     }

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/CheckFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/CheckFilter.vue
@@ -39,9 +39,17 @@ export default Vue.extend({
       // Set `on` from URL only if respective key is in search params...
       if (searchParams.get(this.property) === "true") {
         // and it's value is `true`.
-        this.$data.on = true;
+        this.on = true;
       }
     }
+
+    this.$store.subscribe((mutation, _) => {
+      switch (mutation.type) {
+        case "filters/clearFilters":
+          this.on = false;
+          break;
+      }
+    });
   },
   methods: {
     ...mapMutations("filters", ["registerFilter"]),

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/LabelsFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/LabelsFilter.vue
@@ -34,7 +34,10 @@ export default Vue.extend({
   },
   computed: {
     allLabelKeys: function () {
-      return keys(this.allLabels);
+      // As shown by `selected` type, we expect the `allLabels` to have keys
+      // of type `number`. However, none(?) key-obtaining methods have signature
+      // that would thread this information. Thus, we annotate this here.
+      return keys(this.allLabels) as unknown as number[];
     },
   },
   data: () => {
@@ -70,7 +73,7 @@ export default Vue.extend({
   // When the component is created we set all the labels as unselected
   // and then set those specified in the query string as selected.
   created: function () {
-    this.selected = fromPairs(keys(this.allLabels).map((k) => [k, false]));
+    this.selected = fromPairs(this.allLabelKeys.map((k) => [k, false]));
 
     const searchParams = new URL(window.location.href).searchParams;
     if (searchParams.has(this.property)) {
@@ -87,6 +90,16 @@ export default Vue.extend({
         f: new IntersectionFilter(selectedIds, this.property),
       });
     }
+
+    this.$store.subscribe((mutation, _) => {
+      switch (mutation.type) {
+        case "filters/clearFilters":
+          this.allLabelKeys
+            .filter((key) => this.selected[key])
+            .forEach(this.toggle);
+          break;
+      }
+    });
   },
 });
 </script>

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
@@ -30,7 +30,7 @@ export default Vue.extend({
   },
   data: () => {
     return {
-      selected: undefined,
+      selected: undefined as string | undefined,
     };
   },
   created: function () {
@@ -39,15 +39,14 @@ export default Vue.extend({
       searchParams.get(this.property) == key.toString();
 
     if (searchParams.has(this.property) && this.options.some(isChosenKey)) {
-      // Set selection from URL only if respective key is in search params
-      // and its value is a valid option.
-      this.$data.selected = searchParams.get(this.property);
+      // TypeScript doesn't infer that property is present, manual cast required.
+      this.selected = searchParams.get(this.property) as string;
     }
 
     this.$store.subscribe((mutation, _) => {
       switch (mutation.type) {
         case "filters/clearFilters":
-          this.$data.selected = undefined;
+          this.selected = undefined;
           break;
       }
     });

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/SelectFilter.vue
@@ -43,6 +43,14 @@ export default Vue.extend({
       // and its value is a valid option.
       this.$data.selected = searchParams.get(this.property);
     }
+
+    this.$store.subscribe((mutation, _) => {
+      switch (mutation.type) {
+        case "filters/clearFilters":
+          this.$data.selected = undefined;
+          break;
+      }
+    });
   },
   methods: {
     ...mapMutations("filters", ["registerFilter"]),

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/TextFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/TextFilter.vue
@@ -39,6 +39,14 @@ export default Vue.extend({
       // Set `pattern` from URL only if respective key is in search params.
       this.$data.pattern = searchParams.get(this.property);
     }
+
+    this.$store.subscribe((mutation, _) => {
+      switch (mutation.type) {
+        case "filters/clearFilters":
+          this.$data.pattern = "";
+          break;
+      }
+    });
   },
   methods: {
     ...mapMutations("filters", ["registerFilter"]),

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/TextFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/TextFilter.vue
@@ -36,14 +36,14 @@ export default Vue.extend({
     const searchParams = new URL(window.location.href).searchParams;
 
     if (searchParams.has(this.property)) {
-      // Set `pattern` from URL only if respective key is in search params.
-      this.$data.pattern = searchParams.get(this.property);
+      // TypeScript doesn't infer that property is present, manual cast required.
+      this.pattern = searchParams.get(this.property) as string;
     }
 
     this.$store.subscribe((mutation, _) => {
       switch (mutation.type) {
         case "filters/clearFilters":
-          this.$data.pattern = "";
+          this.pattern = "";
           break;
       }
     });

--- a/zapisy/apps/enrollment/timetable/assets/store/filters.ts
+++ b/zapisy/apps/enrollment/timetable/assets/store/filters.ts
@@ -27,6 +27,11 @@ const mutations = {
   registerFilter(state: State, { k, f }: { k: string; f: Filter }) {
     state.filters[k] = f;
   },
+  // clearFilter can be used to notify filters to reset their state.
+  clearFilters(_: State) {
+    // Intentionally left empty. No state change is required to notify
+    // subscribers of 'filters/clearFilters' mutation.
+  },
 };
 
 const actions = {};

--- a/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
+++ b/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
@@ -7,6 +7,7 @@ import LabelsFilter from "@/enrollment/timetable/assets/components/filters/Label
 import SelectFilter from "@/enrollment/timetable/assets/components/filters/SelectFilter.vue";
 import CheckFilter from "@/enrollment/timetable/assets/components/filters/CheckFilter.vue";
 import { FilterDataJSON } from "@/enrollment/timetable/assets/models";
+import { mapMutations } from "vuex";
 
 export default Vue.extend({
   components: {
@@ -66,6 +67,9 @@ export default Vue.extend({
     if (filterableProperties.some((p: string) => searchParams.has(p))) {
       this.collapsed = false;
     }
+  },
+  methods: {
+    ...mapMutations("filters", ["clearFilters"]),
   },
 });
 </script>
@@ -130,6 +134,14 @@ export default Vue.extend({
             property="recommendedForFirstYear"
             label="Pokaż tylko przedmioty zalecane dla pierwszego roku"
           />
+          <hr />
+          <button
+            class="btn btn-outline-secondary"
+            type="button"
+            @click="clearFilters()"
+          >
+            Wyczyść filtry
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Do `CourseFilter.vue` dodany zostaje guzik, który umożliwi łatwe zresetowanie stanu filtrów.

Nietrywialną częścią implementacji była decyzja, w jaki sposób żądanie zresetowania stanu filtrów ma być przekazane z `CourseFilter` do komponentów odpowiadających różnym filtrom, gdyż Vue.js nie dostarcza idiomatycznego sposobu komunikacji od komponentu-rodzica do komponentów-dzieci.

Przeszukując popularne rozwiązania w internetowych dyskusjach do wyboru było:
1. przy kliknięciu wywołanie metody na każdym komponencie (zidentyfikowanym np. przez przydzielenie każdemu komponentowi filtrującemu atrybutu `ref`),
2. przygotowanie ad-hoc event-busa, przez stworzenie pustego komponentu Vue.js i przekazywanie żądania jako własne zdarzenie w tymże komponencie,
3. przekazywanie żądania jako mutacja w Vuex.


Po rozważeniu rozwiązań doszedłem do wniosków opisanych niżej i postanowiłem wybrać rozwiązanie trzecie.
1. Komponenty z atrybutem `ref` są dostępne w kodzie głównego komponentu pod `this.$refs`, jednakże nie istnieje możliwość pewnego namespace'owania ich (np. by komponenty filtrów mieć zagregowane pod `this.$refs.filters`). Trzeba by zatem filtrować `this.$refs` używając jakiejś dodatkowej informacji.
2. Komunikacja rodzaju event-bus jest uznawana przez autorów jak i środowisko Vue.js za antywzorzec. Gdyby w projekcie była już używana taka konstrukcja, byłbym skory z niej skorzystać, jednak nie dopatrzyłem się jej obecności.
3. Choć ostatecznie wybrane, rozwiązanie nie wydaje się idealne gdyż zdaje się mieszać koncept zdarzeń z konceptem stanu aplikacji. Szczególnie nie podobało mi się tworzenia pola w stanie i przełączania jego wartości (inkrementacja dla liczby, lub negacja dla wartości logicznej) aby wywołać zdarzenie zmiany stanu i jego propagację do obserwatorów.
Szczęśliwe, mutacje nie muszą modyfikować stanu, aby informacja o ich wystąpieniu została rozpropagowana. Pusta definicja `clearFilters` wygląda więc podejrzanie, ale umieszczony komentarz powinien uspokoić obawy czytelnika.

---

Ważną odnotowania bolączką implementacji, jest brak scentralizowanego - na poziomu komponentu - ustalenia jego stanu domyślnego, która teraz odbywa się raz w polu `data` komponentu (przy inicjalizacji), a drugi raz przy otrzymaniu informacji o wystąpieniu mutacji `filters/clearFilters`. Wygląda, że jest to kolejny obszar, które nie posiada w Vue.js dobrego rozwiązania.

Pewnym pomysłem jest [dodanie funkcji konstruującej domyślny stan](https://github.com/vuejs/vue/issues/702) i wykorzystywanie jej w `data` jak i w obserwatorze mutacji. Wadą jest jednak, aby podmiana `data` była uniwersalna, wykorzystanie `Object.assign`, który wyzwala ostrzeżenia, że `data` powinien być jedynie odczytywany.

Innym, [modyfikacja przez rodzica atrybutu `key` komponentów-dzieci](https://michaelnthiessen.com/force-re-render) - powoduje to jednak ponowną inicjalizację komponentu, co wydaje się nadmiarowe.

---

Ten PR jest częścią implementacji trwałych filtrów (patrz https://github.com/iiuni/projektzapisy/issues/1024). Całość zmian w ramach zadania jest agregowana w PRze https://github.com/iiuni/projektzapisy/pull/1129.