### PR TITLE
Wydobywanie nazw filtrowalnych właściwości z template'u

### DIFF
--- a/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
@@ -39,17 +39,15 @@ export default Vue.extend({
       return [Number(k), `${a} ${b}`] as [number, string];
     });
     this.allTypes = toPairs(filtersData.allTypes);
+  },
+  mounted: function() {
+    // Extract filterable properties names from the template.
+    const filterableProperties = Object.values(this.$refs)
+      .filter((ref: any) => ref.filterKey)
+      .map((filter: any) => filter.property);
 
-    const filterableProperties = [
-      "name",
-      "tags",
-      "courseType",
-      "effects",
-      "owner",
-      "recommendedForFirstYear",
-    ];
-    const searchParams = new URL(window.location.href).searchParams;
     // Expand the filters if there are any initially specified in the search params.
+    const searchParams = new URL(window.location.href).searchParams;
     if (filterableProperties.some((p: string) => searchParams.has(p))) {
       this.collapsed = false;
     }
@@ -69,6 +67,7 @@ export default Vue.extend({
             filterKey="name-filter"
             property="name"
             placeholder="Nazwa przedmiotu"
+            ref="name-filter"
           />
           <hr />
           <LabelsFilter
@@ -77,6 +76,7 @@ export default Vue.extend({
             property="tags"
             :allLabels="allTags"
             onClass="badge-success"
+            ref="tags-filter"
           />
         </div>
         <div class="col-md">
@@ -85,6 +85,7 @@ export default Vue.extend({
             property="courseType"
             :options="allTypes"
             placeholder="Rodzaj przedmiotu"
+            ref="type-filter"
           />
           <hr />
           <LabelsFilter
@@ -93,6 +94,7 @@ export default Vue.extend({
             property="effects"
             :allLabels="allEffects"
             onClass="badge-info"
+            ref="effects-filter"
           />
         </div>
         <div class="col-md">
@@ -101,12 +103,14 @@ export default Vue.extend({
             property="owner"
             :options="allOwners"
             placeholder="Opiekun przedmiotu"
+            ref="owner-filter"
           />
           <hr />
           <CheckFilter
             filterKey="freshmen-filter"
             property="recommendedForFirstYear"
             label="Pokaż tylko przedmioty zalecane dla pierwszego roku"
+            ref="freshmen-filter"
           />
           <hr />
           <button

--- a/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
@@ -40,7 +40,7 @@ export default Vue.extend({
     });
     this.allTypes = toPairs(filtersData.allTypes);
   },
-  mounted: function() {
+  mounted: function () {
     // Extract filterable properties names from the template.
     const filterableProperties = Object.values(this.$refs)
       .filter((ref: any) => ref.filterKey)

--- a/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
+++ b/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
@@ -51,19 +51,15 @@ export default Vue.extend({
       ["IN_VOTE", "poddany pod głosowanie"],
       ["WITHDRAWN", "wycofany z oferty"],
     ];
+  },
+  mounted: function() {
+    // Extract filterable properties names from the template.
+    const filterableProperties = Object.values(this.$refs)
+      .filter((ref: any) => ref.filterKey)
+      .map((filter: any) => filter.property);
 
-    const filterableProperties = [
-      "name",
-      "tags",
-      "courseType",
-      "effects",
-      "owner",
-      "recommendedForFirstYear",
-      "semester",
-      "status",
-    ];
-    const searchParams = new URL(window.location.href).searchParams;
     // Expand the filters if there are any initially specified in the search params.
+    const searchParams = new URL(window.location.href).searchParams;
     if (filterableProperties.some((p: string) => searchParams.has(p))) {
       this.collapsed = false;
     }
@@ -83,6 +79,7 @@ export default Vue.extend({
             filterKey="name-filter"
             property="name"
             placeholder="Nazwa przedmiotu"
+            ref="name-filter"
           />
           <hr />
           <LabelsFilter
@@ -91,6 +88,7 @@ export default Vue.extend({
             property="tags"
             :allLabels="allTags"
             onClass="badge-success"
+            ref="tags-filter"
           />
         </div>
         <div class="col-md">
@@ -99,6 +97,7 @@ export default Vue.extend({
             property="courseType"
             :options="allTypes"
             placeholder="Rodzaj przedmiotu"
+            ref="type-filter"
           />
           <hr />
           <LabelsFilter
@@ -107,6 +106,7 @@ export default Vue.extend({
             property="effects"
             :allLabels="allEffects"
             onClass="badge-info"
+            ref="effects-filter"
           />
         </div>
         <div class="col-md">
@@ -115,24 +115,28 @@ export default Vue.extend({
             property="owner"
             :options="allOwners"
             placeholder="Opiekun przedmiotu"
+            ref="owner-filter"
           />
           <SelectFilter
             filterKey="semester-filter"
             property="semester"
             :options="allSemesters"
             placeholder="Semestr"
+            ref="semester-filter"
           />
           <SelectFilter
             filterKey="status-filter"
             property="status"
             :options="allStatuses"
             placeholder="Status propozycji"
+            ref="status-filter"
           />
           <hr />
           <CheckFilter
             filterKey="freshmen-filter"
             property="recommendedForFirstYear"
             label="Pokaż tylko przedmioty zalecane dla pierwszego roku"
+            ref="freshmen-filter"
           />
           <hr />
           <button

--- a/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
+++ b/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
@@ -52,7 +52,7 @@ export default Vue.extend({
       ["WITHDRAWN", "wycofany z oferty"],
     ];
   },
-  mounted: function() {
+  mounted: function () {
     // Extract filterable properties names from the template.
     const filterableProperties = Object.values(this.$refs)
       .filter((ref: any) => ref.filterKey)


### PR DESCRIPTION
W komponentach `CourseFilters` zostały usunięte listy nazw filtrowalnych właściwości. Są teraz tworzone dynamicznie na podstawie template'u.