### PR TITLE
Issue 1097 - Add a view with a list of students for a course

### DIFF
--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -5,11 +5,14 @@
         {{ course.name }}
         <small class="text-muted">{{ course.semester.get_short_name }}</small>
     </h1>
-    {% if user.is_staff or course.owner == request.user.employee %}
-        {% if course.semester.is_current_semester %}
-            <a class="btn btn-sm btn-outline-info float-right align-bottom" href="{% url 'proposal-edit' course.offer.slug %}">Edytuj</a>
+    <div class="btn-group" role="group" aria-label="Basic example">
+        <a class="btn btn-sm btn-outline-info float-right align-bottom" href="{% url 'course-student-list' course.slug %}">Lista</a>
+        {% if user.is_staff or course.owner == request.user.employee %}
+            {% if course.semester.is_current_semester %}
+                <a class="btn btn-sm btn-outline-info float-right align-bottom" href="{% url 'proposal-edit' course.offer.slug %}">Edytuj</a>
+            {% endif %}
         {% endif %}
-    {% endif %}
+    </div>
 </div>
 
 <table class="table table-bordered table-md-responsive" id="table-info">

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_list.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_list.html
@@ -1,5 +1,7 @@
 {% extends "courses/base.html" %}
 
+{% load course_types %}
+
 {% block main-subtitle %}
 	{{ course }}
 {% endblock %}
@@ -35,6 +37,9 @@
     <header class="d-flex justify-content-between align-items-center">
         <div>
             <h1>{{ course }}</h1>
+            {% if class_type %}
+                <h3 class="d-inline-block">{{ class_type|decode_class_type_plural }}</h3>
+            {% endif %}
         </div>
     </header>
 

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_list.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_list.html
@@ -1,0 +1,91 @@
+{% extends "courses/base.html" %}
+
+{% block main-subtitle %}
+	{{ course }}
+{% endblock %}
+
+{% block enrollment_menu_courses %} class="active"{% endblock %}
+
+{% block bread %}
+    <li class="breadcrumb-item">
+        <a href="{% url 'main-page' %}">Strona główna</a>
+    </li>
+
+    <li class="breadcrumb-item">
+        <a href="{% url 'course-list' %}">Zapisy</a>
+    </li>
+
+    <li class="breadcrumb-item">
+	    <a href="{% url 'course-list' %}">Przedmioty</a>
+    </li>
+
+    <li class="breadcrumb-item">
+	    <a href="{% url 'course-page' course.slug %}">
+            {{course.name}}
+        </a>
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">
+        lista
+    </li>
+{% endblock %}
+
+
+
+{% block content %}
+    <header class="d-flex justify-content-between align-items-center">
+        <div>
+            <h1>{{ course }}</h1>
+        </div>
+    </header>
+
+
+    <hr>
+
+    <div class="table-responsive-sm">
+        <h3>Lista osób zapisanych na przedmiot:</h3>
+        <p>
+            Liczba zapisanych osób: {{students_in_course|length}}
+        </p>
+
+        {% if students_in_course %}
+            {% include "courses/students_list.html" with students=students_in_course %}
+            
+            {% if request.user.is_staff or request.user.employee %}
+            <div class="d-print-none">
+                <h5>Wyślij wiadomość do grupy</h5>
+                <ul>
+                    <li><a href="mailto:{{ mailto_group }}">udostępniając adresy mailowe studentów</a></li>
+                    <li><a href="mailto:{{ mailto_group_bcc }}">ukrywając adresy mailowe studentów</a></li>
+                </ul>
+                
+                <h5>Ściągnij listę studentów z grupy jako:</h5>
+                <ul>
+                    <li><a href="{% url 'course-csv' course.slug %}">csv</a></li>
+                </ul>
+            </div>
+            {% endif %}
+        {% endif %}
+    </div>
+
+    <div class="table-responsive-sm d-print-none">
+        {%if students_in_queue %}
+            <h3>Lista osób oczekujących na zapis:</h3>
+            <p>Liczba osób oczekujących na zapis: {{students_in_queue|length}}</p>
+
+            {% include "courses/students_list.html" with students=students_in_queue %}
+            
+            {% if request.user.is_staff or request.user.employee %}
+                <h5>Wyślij wiadomość do kolejki</h5>
+                <ul>
+                    <li><a href="mailto:{{ mailto_queue }}">udostępniając adresy mailowe studentów</a></li>
+                    <li><a href="mailto:{{ mailto_queue_bcc }}">ukrywając adresy mailowe studentów</a></li>
+                </ul>
+
+                <h5>Ściągnij listę studentów z kolejki jako:</h5>
+                <ul>
+                    <li><a href="{% url 'course-queue-csv' course.slug %}">csv</a></li>
+                </ul>
+            {% endif %}
+        {% endif %}
+    </div>
+{% endblock %}

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/groups_section.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/groups_section.html
@@ -4,6 +4,9 @@
 <div class="table-responsive tutorial">
     <h3 class="d-inline-block">{{ class_type|decode_class_type_plural  }} 
     </h3>
+    <a href="{% url 'course-student-list' course.slug %}" class="badge badge-info d-inline-block align-text-bottom ml-2">
+        Lista dla kursu
+    </a>
     {% if class_type in waiting_students %}
         <span class="badge badge-danger d-inline-block align-text-bottom ml-2">
             Niezapisanych&mdash;oczekujących

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/groups_section.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/groups_section.html
@@ -2,11 +2,9 @@
 {% load filters %}
 
 <div class="table-responsive tutorial">
-    <h3 class="d-inline-block">{{ class_type|decode_class_type_plural  }} 
+    <h3 class="d-inline-block">{{ class_type|decode_class_type_plural }}
     </h3>
-    <a href="{% url 'course-student-list' course.slug %}" class="badge badge-info d-inline-block align-text-bottom ml-2">
-        Lista dla kursu
-    </a>
+    <a class="btn btn-sm btn-outline-info float-right align-bottom" href="{% url 'class-type-student-list' course.slug class_type %}">Lista</a>
     {% if class_type in waiting_students %}
         <span class="badge badge-danger d-inline-block align-text-bottom ml-2">
             Niezapisanych&mdash;oczekujących

--- a/zapisy/apps/enrollment/courses/urls.py
+++ b/zapisy/apps/enrollment/courses/urls.py
@@ -13,9 +13,12 @@ from apps.enrollment.courses import views
 urlpatterns = [
     path('', views.courses_list, name='course-list'),
     path('<slug:slug>', views.course_view, name='course-page'),
+    path('<slug:slug>/list', views.course_list_view, name='course-student-list'),
     path('semester/<int:semester_id>', views.courses_list, name='courses-semester'),
     path('group/<int:group_id>', views.group_view, name='group-view'),
     path('group/<int:group_id>/group/csv', views.group_enrolled_csv, name='group-csv'),
     path('group/<int:group_id>/queue/csv', views.group_queue_csv, name='queue-csv'),
+    path('course/<slug:course_slug>/course/csv', views.course_enrolled_csv, name='course-csv'),
+    path('course/<slug:course_slug>/queue/csv', views.course_queue_csv, name='course-queue-csv'),
 
 ]

--- a/zapisy/apps/enrollment/courses/urls.py
+++ b/zapisy/apps/enrollment/courses/urls.py
@@ -13,7 +13,8 @@ from apps.enrollment.courses import views
 urlpatterns = [
     path('', views.courses_list, name='course-list'),
     path('<slug:slug>', views.course_view, name='course-page'),
-    path('<slug:slug>/list', views.course_list_view, name='course-student-list'),
+    path('<slug:course_slug>/list', views.course_list_view, name='course-student-list'),
+    path('<slug:course_slug>/<int:class_type>/list', views.course_list_view, name='class-type-student-list'),
     path('semester/<int:semester_id>', views.courses_list, name='courses-semester'),
     path('group/<int:group_id>', views.group_view, name='group-view'),
     path('group/<int:group_id>/group/csv', views.group_enrolled_csv, name='group-csv'),

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -123,7 +123,6 @@ def course_list_view(request, slug):
     except CourseInstance.DoesNotExist:
         return None, None
 
-
     def get_group_data(group_id):
         group: Group
         try:
@@ -154,29 +153,25 @@ def course_list_view(request, slug):
             .order_by('created')
         )
 
-
         def collect_students(records) -> List[Student]:
             return [record.student for record in records]
-
 
         students_in_group = collect_students(records_in_group)
         students_in_queue = collect_students(records_in_queue)
 
         data = {
-            f'students_in_group': students_in_group,
-            f'students_in_queue': students_in_queue,
-            f'group': group,
-            f'can_user_see_all_students_here': can_user_view_students_list_for_group(
+            'students_in_group': students_in_group,
+            'students_in_queue': students_in_queue,
+            'group': group,
+            'can_user_see_all_students_here': can_user_view_students_list_for_group(
                 request.user, group
             ),
         }
 
         return data
 
-
     def sort_student_by_name(students: List[Student]) -> List[Student]:
         return sorted(students, key=lambda e: (e.user.last_name, e.user.first_name))
-
 
     groups_ids = [group.id for group in course.groups.all()]
     groups_data = [get_group_data(id) for id in groups_ids]
@@ -189,8 +184,12 @@ def course_list_view(request, slug):
     for group_data in groups_data:
         students_in_course.update(group_data['students_in_group'])
     for group_data in groups_data:
-        students_in_queue.update([student for student in group_data['students_in_queue'] if student not in students_in_course])
-        
+        students_in_queue.update([
+            student
+            for student in group_data["students_in_queue"]
+            if student not in students_in_course
+        ])
+
     data = {
             'students_in_course': sort_student_by_name(students_in_course),
             'students_in_queue': sort_student_by_name(students_in_queue),
@@ -295,9 +294,9 @@ def recorded_students_csv(
 
     writer = csv.writer(response)
     for matricula, student in students.items():
-            writer.writerow([
-                    student["first_name"], student["last_name"], matricula, student["email"]
-                ])
+        writer.writerow([
+                student["first_name"], student["last_name"], matricula, student["email"]
+            ])
     return response
 
 
@@ -364,4 +363,9 @@ def course_queue_csv(request, course_slug):
         )
         students_enrolled.update([record.student.matricula for record in records_in_group])
 
-    return recorded_students_csv(group_ids, RecordStatus.QUEUED, course_short_name, exclude_matriculas=students_enrolled)
+    return recorded_students_csv(
+        group_ids,
+        RecordStatus.QUEUED,
+        course_short_name,
+        exclude_matriculas=students_enrolled
+    )


### PR DESCRIPTION
Resolve issue https://github.com/iiuni/projektzapisy/issues/1097
Add a view of all students enrolled and in queue for a course and each type of groups. The view is available with a "Lista" button on the course page in next to the course name, and each group section.

The view is quite similar to the one for a group. It contains a list of enrolled and queued students, a number of enrolled and queued students, the ability to send an email (hidden addresses or not) and to download a csv list.

We define that a student is enrolled in a course, if he is enrolled in any group in the course. A student is in a queue for a course, if he is in a queue for any group and is not enrolled in any group.
