### PR TITLE
Filtrowanie w statystykach

### DIFF
--- a/zapisy/apps/enrollment/records/models/records.py
+++ b/zapisy/apps/enrollment/records/models/records.py
@@ -220,17 +220,34 @@ class Record(models.Model):
             group_type to a number of waiting students.
         """
         queued = Record.objects.filter(
-            status=RecordStatus.QUEUED, group__course__in=courses).values(
+            status=RecordStatus.QUEUED, group__course__in=courses).values(jakiejś
                 'group__course', 'group__type', 'student__user',
                 'student__user__first_name', 'student__user__last_name')
+                
+        to_combine = Record.objects.filter(
+            status=RecordStatus.QUEUED, group__course__in=courses).values(
+                'group__course', 'group__id', 'group__type', 'student__user',
+                'student__user__first_name', 'student__user__last_name')
+        
         enrolled = Record.objects.filter(
             status=RecordStatus.ENROLLED, group__course__in=courses).values(
                 'group__course', 'group__type', 'student__user', 'student__user__first_name',
                 'student__user__last_name')
+       
         waiting = queued.difference(enrolled)
+        
+        wt = []
+        
+        for query in waiting:
+        	for query_all in to_combine:
+        		if ( (query['group__course']==query_all['group__course']) and (query['group__course']==query_all['group__course']) and (query['group__type']==query_all['group__type']) and (query['student__user']==query_all['student__user']) and (query['student__user__first_name']==query_all['student__user__first_name']) and (query['student__user__last_name']==query_all['student__user__last_name']) ):
+        			wt.append(query_all)
+        			break
+        
+	
         ret = defaultdict(lambda: defaultdict(int))
-        for w in waiting:
-            ret[w['group__course']][w['group__type']] += 1
+        for w in wt:
+            ret[w['group__id']][w['group__type']] += 1
         return ret
 
     @classmethod

--- a/zapisy/apps/enrollment/records/models/records.py
+++ b/zapisy/apps/enrollment/records/models/records.py
@@ -220,7 +220,7 @@ class Record(models.Model):
             group_type to a number of waiting students.
         """
         queued = Record.objects.filter(
-            status=RecordStatus.QUEUED, group__course__in=courses).values(jakiejś
+            status=RecordStatus.QUEUED, group__course__in=courses).values(
                 'group__course', 'group__type', 'student__user',
                 'student__user__first_name', 'student__user__last_name')
                 

--- a/zapisy/apps/statistics/templates/statistics/wersja_bez_rowspan.html
+++ b/zapisy/apps/statistics/templates/statistics/wersja_bez_rowspan.html
@@ -9,85 +9,12 @@
 
 <script src="https://www.kryogenix.org/code/browser/sorttable/sorttable.js"></script>
 
-<style>
-
-.switch {
-  position: relative;
-  display: inline-block;
-  width: 60px;
-  height: 34px;
-}
-
-.switch input { 
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-.slider {
-
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #ccc;
-  -webkit-transition: .4s;
-  transition: .4s;
-}
-
-.slider:before {
-  position: absolute;
-  content: "";
-  height: 26px;
-  width: 26px;
-  left: 4px;
-  bottom: 4px;
-  background-color: white;
-  -webkit-transition: .4s;
-  transition: .4s;
-}
-
-input:checked + .slider {
-  background-color: #2196F3;
-}
-
-input:focus + .slider {
-  box-shadow: 0 0 1px #2196F3;
-}
-
-input:checked + .slider:before {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
-}
-
-/* Rounded sliders */
-.slider.round {
-  border-radius: 34px;
-}
-
-.slider.round:before {
-  border-radius: 50%;
-}
-</style>
-
-
-
-<label id="label_filter"> Filter OFF </label>
-
-<label class="switch">
-  <input type="checkbox" id="slider" onclick="filter()">
-  <span class="slider round"></span>
-</label>
-
 
 <div class="table-responsive">
 
     {% regroup groups by course as courses_list %}
 
-    <table id="mytab" class="table table-striped sortable">
+    <table class="table table-striped table-condensed table-bordered sortable">
         <thead class="text-muted">
             <tr>
             	<th scope="col">Przedmiot</th>
@@ -96,7 +23,6 @@ input:checked + .slider:before {
                 <th scope="col">Miejsca</th>
                 <th scope="col">Zapisani</th>
                 <th scope="col">Kolejka</th>
-                <th scope="col">Niezapisani</th>
                 <th scope="col">Przypięci</th>
                 <th></th>
             </tr>
@@ -104,9 +30,9 @@ input:checked + .slider:before {
         <tbody>
             {% for course, groups in courses_list %}
             
- 
+            
+  
                 {% for group in groups %}
-                <tr id='result_tr'>
                         <td> {{ course.name }} </td>                   
                         <td>{{group.teacher}}</td>
                         <td>{{ group.get_type_display }}</td>
@@ -121,15 +47,6 @@ input:checked + .slider:before {
                         </td>
                         <td>{{ group.enrolled }}</td>
                         <td>{{ group.queued }}</td>
-                        
-                     <td>
-                        {% with waiting_course=waiting_students|lookup:group.id %}
-                            {% for course_type in waiting_course %}
-                                        {{ waiting_course|lookup:course_type }}
-                            {% endfor %}
-                        {% endwith %}
-                    </td>
-                                              
                         <td>{{ group.pinned }}</td>
                         <td>
                             <a class="badge badge-sm badge-primary"
@@ -147,39 +64,11 @@ input:checked + .slider:before {
 </div>
 
 <script>
+$(function() {
+  $.bootstrapSortable({ sign: 'reversed', applyLast: false })
+  
+});
 
-
-
-document.getElementById("slider").checked=false;
-
-
-function filter(){
-
-var lbl = document.getElementById("label_filter");
-var slid = document.getElementById("slider");
-if(slid.checked==false){
-lbl.innerText="Filter OFF";
-for (let row of mytab.rows) 
-{
-    cell = row.cells[6];
-       if (cell.innerText!=""){
-            
-            row.style.display= 'table-row'; 
-       } 
-}
-}
-else{
-lbl.innerText="Filter ON";
-for (let row of mytab.rows) 
-{
-    cell = row.cells[6];
-       if (cell.innerText==""){
-            
-            row.style.display= 'none'; 
-       } 
-}
-}
-}
 </script>
 
 {% endblock %}

--- a/zapisy/apps/statistics/views.py
+++ b/zapisy/apps/statistics/views.py
@@ -41,7 +41,9 @@ def groups(request):
                 enrolled=enrolled_agg).annotate(queued=queued_agg).annotate(pinned=pinned_agg)
     waiting_students = Record.list_waiting_students(
         CourseInstance.objects.filter(semester=semester))
+    i=0
     return render(request, 'statistics/groups_list.html', {
         'groups': groups,
         'waiting_students': waiting_students,
+        'i' : i,
     })

--- a/zapisy/requirements.common.txt
+++ b/zapisy/requirements.common.txt
@@ -14,6 +14,8 @@ django-webpack-loader==0.7.0
 djangorestframework==3.12.4
 django-pagedown==2.2.1
 
+pyparsing==2.4.7
+
 ipdb==0.13.9
 prompt-toolkit==3.0.23
 ipython==7.30.1


### PR DESCRIPTION
Działa filtrowanie, które wyświetla tylko grupy, które mają przynajmniej jedną taką osobę, która zapisana jest na daną grupę w obrębie kursu, ale nie jest w żadnej grupie (przycisk FILTER ON/OFF widoczny na zrzucie). Ponadto działa sortowanie po headerach tabeli w tym również pożądany "niezapisani", który właśnie reprezentuje te osoby. Czyli podsumowując header "niezapisani" reprezentuje osoby, które są w kolejce do danej grupy, ale nie są zapisani (oczywiście w obrębie tych samych typów grup czyli np. w obrębie pracowni, w obrębie seminariów itd.).
![obraz](https://user-images.githubusercontent.com/15573725/148795893-a5127b37-1012-4122-bc8d-77de979691fb.png)
![obraz](https://user-images.githubusercontent.com/15573725/148795910-7ceb24d5-15ef-477f-93c5-a029c2825494.png)
![obraz](https://user-images.githubusercontent.com/15573725/148795945-f6d22bda-7e73-47ee-a20e-ed6356780b50.png)
