### PR TITLE
Replace `git://` by `https://` in git dependency remote URLs

### DIFF
--- a/zapisy/package.json
+++ b/zapisy/package.json
@@ -20,7 +20,7 @@
     "axios": "0.21.4",
     "big-integer": "1.6.51",
     "bootstrap": "4.6.1",
-    "bootstrap-sortable": "git://github.com/drvic10k/bootstrap-sortable.git#ff650fd17cc2872f4031d355fa6382066d064e87",
+    "bootstrap-sortable": "https://github.com/drvic10k/bootstrap-sortable.git#ff650fd17cc2872f4031d355fa6382066d064e87",
     "checkboxes.js": "1.2.2",
     "dayjs": "1.10.8",
     "jquery": "3.6.0",

--- a/zapisy/yarn.lock
+++ b/zapisy/yarn.lock
@@ -2836,9 +2836,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bootstrap-sortable@git://github.com/drvic10k/bootstrap-sortable.git#ff650fd17cc2872f4031d355fa6382066d064e87":
+"bootstrap-sortable@https://github.com/drvic10k/bootstrap-sortable.git#ff650fd17cc2872f4031d355fa6382066d064e87":
   version: 1.11.2
-  resolution: "bootstrap-sortable@git://github.com/drvic10k/bootstrap-sortable.git#commit=ff650fd17cc2872f4031d355fa6382066d064e87"
+  resolution: "bootstrap-sortable@https://github.com/drvic10k/bootstrap-sortable.git#commit=ff650fd17cc2872f4031d355fa6382066d064e87"
   checksum: 5d91772b8523bbb7493f1e3a43c752f34e9eb9a1138c3b75e69090c9ac2909fab93a0a07b58bbc72f5fd03e9b43411581e0bb45e8e25824e5007d96fbebdc33d
   languageName: node
   linkType: hard
@@ -5217,7 +5217,7 @@ fsevents@~2.1.2:
     babel-loader: 8.2.3
     big-integer: 1.6.51
     bootstrap: 4.6.1
-    bootstrap-sortable: "git://github.com/drvic10k/bootstrap-sortable.git#ff650fd17cc2872f4031d355fa6382066d064e87"
+    bootstrap-sortable: "https://github.com/drvic10k/bootstrap-sortable.git#ff650fd17cc2872f4031d355fa6382066d064e87"
     checkboxes.js: 1.2.2
     clean-webpack-plugin: 3.0.0
     cookieconsent: 3.1.1


### PR DESCRIPTION
Nikt nie mógł się spodziewać, że zapowiadane od miesięcy zmiany w polityce dostępności GitHuba sprawią nam jakieś problemy. Od paru dni nie działa instalacja zależności przez Yarn, bo jedna z nich pobierana jest z GitHuba, z _remote_ podanym w postaci `git://github.com/...` który obecnie wymaga uwierzytelnienia. Bieżąca poprawka zamienia `git://` na `https://` (w `package.json` i – wygenerowanym automatycznie – `yarn.lock`), co rozwiązuje problem.