### PR TITLE
RefreshError on assignments

### DIFF
--- a/zapisy/apps/offer/assignments/views.py
+++ b/zapisy/apps/offer/assignments/views.py
@@ -48,7 +48,8 @@ def plan_view(request):
         messages.error(request, error)
         return render(request, 'assignments/view.html', {'year': year})
     except RefreshError as error:
-        messages.error(request, f"<p>Proszę sprawdzić konfigurację arkuszy Google.</p>{error}")
+        messages.error(request, f"""<h4>Błąd w konfiguracji arkuszy Google.</h4>
+                       {error}""")
         return render(request, 'assignments/view.html', {'year': year})
 
     courses: Dict[str, AssignmentsViewSummary] = {'z': {}, 'l': {}}

--- a/zapisy/apps/offer/assignments/views.py
+++ b/zapisy/apps/offer/assignments/views.py
@@ -15,6 +15,8 @@ from django.shortcuts import HttpResponse, redirect, render
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 
+from google.auth.exceptions import RefreshError
+
 from apps.offer.proposal.models import Proposal, ProposalStatus, SemesterChoices
 from apps.offer.vote.models.system_state import SystemState
 from apps.users.decorators import employee_required
@@ -44,6 +46,9 @@ def plan_view(request):
             filter(lambda a: a.confirmed, read_assignments_sheet(assignments_spreadsheet)))
     except (KeyError, ValueError) as error:
         messages.error(request, error)
+        return render(request, 'assignments/view.html', {'year': year})
+    except RefreshError as error:
+        messages.error(request, f"<p>Proszę sprawdzić konfigurację arkuszy Google.</p>{error}")
         return render(request, 'assignments/view.html', {'year': year})
 
     courses: Dict[str, AssignmentsViewSummary] = {'z': {}, 'l': {}}


### PR DESCRIPTION
Unhandled RefreshError occurred on offer/assignments page. It was caused by missing Google Sheets configuration. PR adds handling RefreshError with displaying more informative message.

Closes #1209.