### PR TITLE
Podsumowywanie prototypu planu zajęć studenta

### DIFF
--- a/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
+++ b/zapisy/apps/enrollment/timetable/templates/timetable/prototype.html
@@ -80,6 +80,72 @@
             </li>
         </ul>
     </div>
+    {% if user.student %}
+    <h3>{% trans "Zajęcia, na które jesteś zapisany" %}</h3>
+    <div class="table-responsive">
+	<table id="enr-schedule-listByCourse" class="table table-striped">
+		<thead>
+			<tr>
+                {# Translators: Tytuł kolumny w tabelce #}
+				<th scope="col">{% trans "Przedmiot" %}</th>
+				{% if user.student %}
+                    {# Translators: Tytuł kolumny w tabelce #}
+                    <th class="ects" scope="col">{% trans "ECTS" %}</th>
+                {% else %}
+                    {# Translators: Tytuł kolumny w tabelce #}
+                    <th class="ects" scope="col">{% trans "Godziny" %}</th>
+                {% endif %}
+			</tr>
+		</thead>
+		<tfoot>
+			<tr>
+                <td><strong>Suma punktów ECTS:</strong></td>
+                <td class="ects">{{ sum_points }}</td>
+			</tr>
+		</tfoot>
+		<tbody>
+            {% regroup groups|dictsort:"course_id" by course as courses %}
+            {% for course in courses %}
+            <tr class="courseHeader">
+                <td class="name" scope="col">
+                    <a href="{% url 'course-page' course.grouper.slug %}">
+                        {{ course.grouper.name }}
+                    </a>
+
+                </td>
+                <td rowspan="2" class="ects">
+                    {{ course.grouper.points }}
+                </td>
+            </tr>
+            <tr class="courseDetails">
+                <td>
+                    <ul>
+                        {% for item in course.list %}
+                        {% with item as group %}
+                        <li>
+                            <span class="type">{{ group.get_type_display }}:</span>
+                            {% for term in group.term.all %}
+                            <span class="term">
+                                {{ term.get_dayOfWeek_display }}
+                                {{ term.start_time|time:'G:i' }}-{{ term.end_time|time:'G:i' }}
+                            </span>
+                            <span class="classroom">sala:
+                                  {% for classroom in term.classrooms.all %}
+                                    {{ classroom.number }}
+                                  {% endfor %}
+                            </span>
+                            {% endfor %}
+                        </li>
+                        {% endwith %}
+                        {% endfor %}
+                    </ul>
+                </td>
+            </tr>
+            {% endfor %}
+		</tbody>
+    </table>
+    </div>  
+    {% endif %}
 {% endblock %}
 
 {% block rendered_bundles %}

--- a/zapisy/apps/enrollment/timetable/views.py
+++ b/zapisy/apps/enrollment/timetable/views.py
@@ -174,10 +174,14 @@ def my_prototype(request):
     filters_dict = CourseInstance.prepare_filter_data(
         CourseInstance.objects.filter(semester=semester))
     courses_json = list_courses_in_semester(semester)
+    points_for_courses = {r.group.course.id: r.group.course.points for r in records}
+    groups = [r.group for r in records]
     data = {
         'groups_json': group_dicts,
         'filters_json': filters_dict,
         'courses_json': courses_json,
+        'groups': groups,
+        'sum_points': sum(points_for_courses.values()),
     }
     return render(request, 'timetable/prototype.html', data)
 


### PR DESCRIPTION
### TLDR #1231
- W trakcie układania planu zajęć na nowy semestr studenci muszą sami zliczać sobie punkty ECTS, które zdobędą. Często ułożony plan zajęć bardzo szybko może się zmienić w czasie otwarcia zapisów dla studenta. Takie automatyczne podsumowywanie usprawni, więc planowanie planu zajęć na nowy semestr.
### Definicje
- przedmioty(Z) to są przedmioty, które są przypięte do prototypu zajęć, na które student jest zapisany.
- przedmioty(P) to są przedmioty, które są przypięte do prototypu zajęć.
- przedmioty(K) to są przedmioty, które są przypięte do prototypu zajęć, na które student zapisał się do kolejki.
- przedmioty(L) to są przedmioty, które nie są przypięte do planu, które student dodał do planu poprzez listę przedmiotów dostępną w prototypie.

### TODO
- [X] Dodanie przedmiotów (Z) do podsumowywania.
- [ ] Dodanie przedmiotów (P) do podsumowywania.
- [ ] Dodanie przedmiotów (K) do podsumowywania.
- [ ] Dodanie przedmiotów (L) do podsumowywania.
- [ ] Dodanie przedmiotów (Z, P, K i L) do podsumowywania.
- [ ] Opcje filtrowania w podsumowywaniu po rodzajach przedmiotów.



