### PR TITLE
1259 issue - data regex

### DIFF
--- a/zapisy/apps/schedule/urls.py
+++ b/zapisy/apps/schedule/urls.py
@@ -4,8 +4,7 @@ from . import feeds, views
 
 urlpatterns = [
     path('classrooms/', views.classrooms, name='classrooms'),
-    re_path(r'^classrooms/get_terms/(?P<year>[0-9]{4})-(?P<month>[1-9]|0[1-9]|1[0-2])-\
-            (?P<day>[1-9]|0[1-9]|[12][0-9]|3[01])/$',
+    re_path(r'^classrooms/get_terms/(?P<year>[0-9]{4})-(?P<month>[0-9]{1,2})-(?P<day>[0-9]{1,2})/$',
             views.get_terms,
             name='get_terms'),
     path('classrooms/reservation/', views.new_reservation, name='reservation'),

--- a/zapisy/apps/schedule/urls.py
+++ b/zapisy/apps/schedule/urls.py
@@ -4,7 +4,7 @@ from . import feeds, views
 
 urlpatterns = [
     path('classrooms/', views.classrooms, name='classrooms'),
-    re_path(r'^classrooms/get_terms/(?P<year>[0-9]{4})-(?P<month>[0-9]{1,2})-(?P<day>[0-9]{1,2})/$',
+    re_path(r'^classrooms/get_terms/(?P<year>[0-9]{4})-(?P<month>0[1-9]|1[0-2])-(?P<day>[0-9]{1,2})/$',
             views.get_terms,
             name='get_terms'),
     path('classrooms/reservation/', views.new_reservation, name='reservation'),

--- a/zapisy/apps/schedule/urls.py
+++ b/zapisy/apps/schedule/urls.py
@@ -4,7 +4,8 @@ from . import feeds, views
 
 urlpatterns = [
     path('classrooms/', views.classrooms, name='classrooms'),
-    re_path(r'^classrooms/get_terms/(?P<year>[0-9]{4})-(?P<month>[1-9]|0[1-9]|1[0-2])-(?P<day>[1-9]|0[1-9]|[12][0-9]|3[01])/$',
+    re_path(r'^classrooms/get_terms/(?P<year>[0-9]{4})-(?P<month>[1-9]|0[1-9]|1[0-2])-\
+            (?P<day>[1-9]|0[1-9]|[12][0-9]|3[01])/$',
             views.get_terms,
             name='get_terms'),
     path('classrooms/reservation/', views.new_reservation, name='reservation'),

--- a/zapisy/apps/schedule/urls.py
+++ b/zapisy/apps/schedule/urls.py
@@ -4,7 +4,7 @@ from . import feeds, views
 
 urlpatterns = [
     path('classrooms/', views.classrooms, name='classrooms'),
-    re_path(r'^classrooms/get_terms/(?P<year>[0-9]{4})-(?P<month>0[1-9]|1[0-2])-(?P<day>[0-9]{1,2})/$',
+    re_path(r'^classrooms/get_terms/(?P<year>[0-9]{4})-(?P<month>[1-9]|0[1-9]|1[0-2])-(?P<day>[1-9]|0[1-9]|[12][0-9]|3[01])/$',
             views.get_terms,
             name='get_terms'),
     path('classrooms/reservation/', views.new_reservation, name='reservation'),

--- a/zapisy/apps/schedule/views.py
+++ b/zapisy/apps/schedule/views.py
@@ -263,7 +263,10 @@ def change_interested(request, event_id):
 
 @login_required
 def get_terms(request, year, month, day):
-    date = datetime.date(int(year), int(month), int(day))
+    try:
+        date = datetime.date(int(year), int(month), int(day))
+    except:
+        raise Http404
 
     def make_dict(start_time, end_time):
         return {

--- a/zapisy/apps/schedule/views.py
+++ b/zapisy/apps/schedule/views.py
@@ -266,7 +266,7 @@ def get_terms(request, year, month, day):
     try:
         date = datetime.date(int(year), int(month), int(day))
     except ValueError:
-        raise Http404
+        raise Http404("URL contains invalid date.")
 
     def make_dict(start_time, end_time):
         return {

--- a/zapisy/apps/schedule/views.py
+++ b/zapisy/apps/schedule/views.py
@@ -265,7 +265,7 @@ def change_interested(request, event_id):
 def get_terms(request, year, month, day):
     try:
         date = datetime.date(int(year), int(month), int(day))
-    except:
+    except ValueError:
         raise Http404
 
     def make_dict(start_time, end_time):


### PR DESCRIPTION
Problem pojawiał się w momencie, kiedy została uruchamiana strona np. https://0.0.0.0:8000/classrooms/get_terms/2022-42-02 , gdzie 42 oznaczał miesiąc. Podobny problem pojawiał się, gdy wpisano dzień, który w danym miesiącu nie istnieje.
Napisanie dokładnego regeksu w urlpatterns byłoby nieczytelne i trudne, dlatego wprowadzona zmiana to wyrzucenie wyjątku (Error404) w przypadku wpisania niepoprawnej daty.

_[Wyedytowałem URL, żeby ewentualni klikający nie generowali niepotrzebnych raportów z Rollbara. —plg]_