### PR TITLE
Duplikaty w kalendarzach

### DIFF
--- a/zapisy/apps/schedule/views.py
+++ b/zapisy/apps/schedule/views.py
@@ -330,7 +330,9 @@ class EventsTermsAjaxView(FullCalendarView):
 
     def get_queryset(self):
         queryset = super(EventsTermsAjaxView, self).get_queryset()
-        queryset = queryset.filter(event__type='2', event__visible=True)
+        queryset = queryset.filter(event__type='2', event__visible=True)\
+            .order_by('event__title', 'start', 'end', 'day')\
+            .distinct('event__title', 'start', 'end', 'day')
         return queryset
 
 

--- a/zapisy/apps/schedule/views.py
+++ b/zapisy/apps/schedule/views.py
@@ -321,7 +321,10 @@ class ClassroomTermsAjaxView(FullCalendarView):
 
     def get_queryset(self):
         queryset = super(ClassroomTermsAjaxView, self).get_queryset()
-        return queryset.filter(room__slug=self.kwargs['slug'])
+        queryset = queryset.filter(room__slug=self.kwargs['slug'])\
+            .order_by('event__title', 'start', 'end', 'day')\
+            .distinct('event__title', 'start', 'end', 'day')
+        return queryset
 
 
 class EventsTermsAjaxView(FullCalendarView):


### PR DESCRIPTION
Wielokrotne wyświetlanie tego samego wydarzenia w wielu salach
Błąd polegał na pokazywaniu duplikatów wydarzeń/zajęć w widoku w kalendarzu (https://zapisy.ii.uni.wroc.pl/classrooms/ oraz https://zapisy.ii.uni.wroc.pl/events/).
W obu przypadkach, proponowana naprawa błędu polega na filtrowaniu pokazywanych wydarzeń po polach 'event__title', 'start', 'end', 'day'.
Błąd wynika ze sposobem zapisu wydarzenia odbywającego się w  wielu salach. Dodanie kilku sal do jednego wydarzenia wymaga użycia opcji: dodaj nowy termin. Z tego powodu wielokrotne wystąpienia wydarzenia w kalendarzu w tych samych godzinach, ale różnych salach wciąż są traktowane jako osobne terminy, więc nie są łączone w jeden widoczny kafelek.
Zapis wydarzeń jest poprawny, sposób wyświetlania w kalendarzu dla wydarzeń odbywających się w różnych terminach również, dlatego zmiany obejmują jedynie dodanie dodatkowych parametrów filtrowania.