### PR TITLE
864 zaznaczanie nieprzeczytanych fragmentów oceny zajęć

### DIFF
--- a/zapisy/apps/grade/poll/models.py
+++ b/zapisy/apps/grade/poll/models.py
@@ -8,7 +8,7 @@ from apps.enrollment.courses.models.course_instance import CourseInstance
 from apps.enrollment.courses.models.group import Group, GroupType
 from apps.enrollment.courses.models.semester import Semester
 from apps.enrollment.records import models as records_models
-from apps.users.models import Student
+from apps.users.models import Employee, Student
 
 
 class PollType(models.IntegerChoices):
@@ -395,3 +395,9 @@ class Submission(models.Model):
             submission.save()
 
         return submission
+
+class Viewed(models.Model):
+    """Represents the last time employee viewed poll."""
+    user = models.ForeignKey(Employee, on_delete=models.CASCADE)
+    poll = models.ForeignKey(Poll, on_delete=models.CASCADE)
+    time = models.DateTimeField()

--- a/zapisy/apps/grade/poll/models.py
+++ b/zapisy/apps/grade/poll/models.py
@@ -396,6 +396,7 @@ class Submission(models.Model):
 
         return submission
 
+
 class Viewed(models.Model):
     """Represents the last time employee viewed poll."""
     user = models.ForeignKey(Employee, on_delete=models.CASCADE)

--- a/zapisy/apps/grade/poll/templates/poll/results.html
+++ b/zapisy/apps/grade/poll/templates/poll/results.html
@@ -53,7 +53,7 @@
     {% empty %}
     <div class="mb-3">
       {% if current_poll %}
-      Nie została wypełniona żadna ankieta.
+      Nie została wypełniona ani jedna ankieta.
       {% else %}
       Nie wybrano żadnej grupy.
       {% endif %}

--- a/zapisy/apps/grade/poll/templates/poll/results.html
+++ b/zapisy/apps/grade/poll/templates/poll/results.html
@@ -76,9 +76,13 @@
       <div class="card">
         <div class="card-header" style="cursor: pointer;" id="course-section-{{ index }}-heading" data-toggle="collapse"
           data-target="#course-section-{{ index }}" aria-expanded="false" aria-controls="course-section-{{ index }}">
-          <div class="d-flex w-100 justify-content-between">
+          {% with x=submissions_count|lookup:group_name %}
+          {% if read.0|lookup:group_name or x == 0 %}
+            <div class="d-flex w-100 justify-content-between">
+          {% else %}
+          <div class="d-flex w-100 justify-content-between" style="color:red">
+            {% endif %}
             <span>{{ group_name }}</span>
-            {% with x=submissions_count|lookup:group_name %}
             <span class="text-right text-nowrap">
               {% if x %}{{ x }}{% else %}0{% endif %}
             </span>
@@ -100,7 +104,11 @@
           {% else %}
           <a href="{% url 'grade-poll-results' semester_id=selected_semester.id poll_id=entry.id %}"
             class="list-group-item list-group-item-action">
+            {% if read.1|lookup:entry or entry.number_of_submissions == 0 %}
             <div class="d-flex w-100 justify-content-between">
+          {% else %}
+          <div class="d-flex w-100 justify-content-between" style="color:red">
+            {% endif %}
               <span>{{ entry.subcategory }}</span>
               <span class="text-right text-nowrap">{{ entry.number_of_submissions }}</span>
             </div>

--- a/zapisy/apps/grade/poll/templates/poll/results.html
+++ b/zapisy/apps/grade/poll/templates/poll/results.html
@@ -53,7 +53,7 @@
     {% empty %}
     <div class="mb-3">
       {% if current_poll %}
-      Nie została wypełniona ani jedna ankieta.
+      Nie została wypełniona żadna ankieta.
       {% else %}
       Nie wybrano żadnej grupy.
       {% endif %}

--- a/zapisy/apps/grade/poll/views.py
+++ b/zapisy/apps/grade/poll/views.py
@@ -1,8 +1,9 @@
+import datetime
 import itertools
 import json
 from collections import defaultdict
 from operator import attrgetter
-from typing import List
+from typing import Dict, List
 
 from django.contrib import messages
 from django.shortcuts import redirect, render, reverse
@@ -10,7 +11,7 @@ from django.views.generic import TemplateView, UpdateView, View
 
 from apps.enrollment.courses.models.semester import Semester
 from apps.grade.poll.forms import SubmissionEntryForm, TicketsEntryForm
-from apps.grade.poll.models import Poll, Submission
+from apps.grade.poll.models import Poll, Submission, Viewed
 from apps.grade.poll.utils import (PollSummarizedResults, SubmissionStats, check_grade_status,
                                    group)
 from apps.grade.ticket_create.models.rsa_keys import RSAKeys
@@ -181,7 +182,7 @@ class PollResults(TemplateView):
                 ] += poll.number_of_submissions
 
         return number_of_submissions_for_category
-      
+
     @staticmethod
     def __get_unread(polls, user):
         un_read = defaultdict(True.__bool__)
@@ -203,9 +204,9 @@ class PollResults(TemplateView):
                         pass
                 else:
                     un_read_sing[poll] = False
-                    un_read[poll.category]=False
+                    un_read[poll.category] = False
 
-        return [un_read,un_read_sing]
+        return [un_read, un_read_sing]
 
     @staticmethod
     def __get_processed_results(submissions):

--- a/zapisy/apps/grade/poll/views.py
+++ b/zapisy/apps/grade/poll/views.py
@@ -182,7 +182,7 @@ class PollResults(TemplateView):
 
         return number_of_submissions_for_category
       
-      @staticmethod
+    @staticmethod
     def __get_unread(polls, user):
         un_read = defaultdict(True.__bool__)
         un_read_sing = defaultdict(True.__bool__)


### PR DESCRIPTION
Pull request dotyczy wprowadzenia zaznaczania na czerwono ankiet i ich kategorii, kiedy pojawi się w nich coś nowego. PR jest związany z issue nr 864. Nie jest to ścisłe przywrócenie funkcjonalności, o której w tym issue pisał p. Łukasz Piwowar. Niedługo przed założeniem tego issue kod oceny zajeć został radykalnie przepisany. Spędziłem dużo czasu na analizowaniu starej wersji oceny, w imię zasady, że użytkownicy lubią znane im interfejsy i że kod już kiedyś zmergowany może być przykładem dobrych wzorców. Jednak ostatecznie zdecydowałem się inaczej dodać tę funkcjonalność, w szczególności ze względu na skalę różnic względem aktualnej wersji, które mogłyby sprawić, że znalezione rozwiązania trudno zastosować przy obecnym kodzie.