### PR TITLE
Added MultiselectFilter with vue-multiselect

### DIFF
--- a/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/CourseFilter.vue
@@ -5,6 +5,7 @@ import Vue from "vue";
 import TextFilter from "./filters/TextFilter.vue";
 import LabelsFilter from "./filters/LabelsFilter.vue";
 import SelectFilter from "./filters/SelectFilter.vue";
+import MultiselectFilter from "./filters/MultiselectFilter.vue";
 import CheckFilter from "./filters/CheckFilter.vue";
 import { FilterDataJSON } from "./../models";
 import { mapMutations } from "vuex";
@@ -14,6 +15,7 @@ export default Vue.extend({
     TextFilter,
     LabelsFilter,
     SelectFilter,
+    MultiselectFilter,
     CheckFilter,
   },
   data: function () {
@@ -33,8 +35,8 @@ export default Vue.extend({
     ) as FilterDataJSON;
     this.allEffects = cloneDeep(filtersData.allEffects);
     this.allTags = cloneDeep(filtersData.allTags);
-    this.allOwners = sortBy(toPairs(filtersData.allOwners), ([k, [a, b]]) => {
-      return b;
+    this.allOwners = toPairs(filtersData.allOwners).sort(([k1, [a1, b1]], [k2, [a2, b2]]) => {
+      return b1.localeCompare(b2, 'pl');
     }).map(([k, [a, b]]) => {
       return [Number(k), `${a} ${b}`] as [number, string];
     });
@@ -80,7 +82,7 @@ export default Vue.extend({
           />
         </div>
         <div class="col-md">
-          <SelectFilter
+          <MultiselectFilter
             filterKey="type-filter"
             property="courseType"
             :options="allTypes"
@@ -98,7 +100,7 @@ export default Vue.extend({
           />
         </div>
         <div class="col-md">
-          <SelectFilter
+          <MultiselectFilter
             filterKey="owner-filter"
             property="owner"
             :options="allOwners"

--- a/zapisy/apps/enrollment/timetable/assets/components/filters/MultiselectFilter.vue
+++ b/zapisy/apps/enrollment/timetable/assets/components/filters/MultiselectFilter.vue
@@ -1,0 +1,76 @@
+<script lang="ts">
+import { isEmpty, property } from "lodash";
+import Vue from "vue";
+import Multiselect from 'vue-multiselect'
+import { mapMutations } from "vuex";
+
+import { Filter } from "../../store/filters";
+
+class ExactMultiFilter implements Filter {
+  constructor(public ids: number[], public propertyName: string) {}
+
+  visible(c: Object): boolean {
+    if (isEmpty(this.ids)) {
+      return true;
+    }
+    let propGetter = property(this.propertyName) as (c: Object) => number;
+    let propValue = propGetter(c);
+    return this.ids.includes(propValue);
+  }
+}
+
+// TextFilter applies the string filtering on a property of a course.
+export default Vue.extend({
+  components: {
+    Multiselect
+  },
+  props: {
+    property: String,
+    filterKey: String,
+    options: Array as () => [number, string][],
+    placeholder: String,
+  },
+  data: () => {
+    return {
+      selected: [],
+      optionsObjs: []
+    };
+  },
+  created: function () {
+    this.optionsObjs = this.options.map(([a, b]) => {return {id: Number(a), name: b}});
+    this.placeholderDecorated = '-- ' + this.placeholder + ' --';
+
+    this.$store.subscribe((mutation, _) => {
+      switch (mutation.type) {
+        case "filters/clearFilters":
+          this.selected = [];
+          break;
+      }
+    });
+  },
+  methods: {
+    ...mapMutations("filters", ["registerFilter"]),
+  },
+  watch: {
+    selected: function (newSelected: string | undefined) {
+      const selectedIds = this.selected.map((el) => {return el.id});
+
+      this.registerFilter({
+        k: this.filterKey,
+        f: new ExactMultiFilter(selectedIds, this.property),
+      });
+    },
+  },
+});
+</script>
+
+<style src="vue-multiselect/dist/vue-multiselect.min.css"></style>
+
+<template>
+  <div class="input-group mb-2">
+    <multiselect v-model="selected" :options="optionsObjs" :multiple="true" :close-on-select="true" :clear-on-select="true"
+        :searchable="false" :allow-empty="true" :placeholder="placeholderDecorated" track-by="id" label="name"
+        selectLabel="" selectedLabel="" deselectLabel="">
+    </multiselect>
+  </div>
+</template>

--- a/zapisy/package.json
+++ b/zapisy/package.json
@@ -70,6 +70,7 @@
     "typescript": "4.0.2",
     "vue-class-component": "7.2.6",
     "vue-loader": "15.9.8",
+    "vue-multiselect": "2.1.4",
     "vue-template-compiler": "2.6.14",
     "webpack": "4.46.0",
     "webpack-bundle-analyzer": "3.9.0",

--- a/zapisy/yarn.lock
+++ b/zapisy/yarn.lock
@@ -5475,6 +5475,7 @@ fsevents@~2.1.2:
     vue: 2.6.14
     vue-class-component: 7.2.6
     vue-loader: 15.9.8
+    vue-multiselect: 2.1.4
     vue-template-compiler: 2.6.14
     vue-timers: 2.0.4
     vuex: 3.6.2
@@ -9234,6 +9235,13 @@ typescript@4.0.2:
     vue-template-compiler:
       optional: true
   checksum: bbbf069081b867f8b3135e51444818bae8199239f7718ebf484a4e81ddbb17629673d5a2eabb2abf4b2b822dd0fa75b78b487ab1f085714e0728a4c475536a74
+  languageName: node
+  linkType: hard
+
+"vue-multiselect@npm:2.1.4":
+  version: 2.1.4
+  resolution: "vue-multiselect@npm:2.1.4"
+  checksum: a77de83a10aa2c5a03b62934f5be0939452600b44f080a9f2e2568627567ebf1920f9054317ea277d115ac34adeeb2c35e14e1cc1d675a41d5b6ee6220b961da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ten PR używa vue-multiselect w celu dodania filtrowania po wielu rodzajach przedmiotu i opiekuna przedmiotu.

Ta wersja raczej nie jest końcowym podejściem. Co prawda pozwala na wielokrotne wybieranie:
![image](https://user-images.githubusercontent.com/25225728/177477276-2cab6aea-6a2c-4e24-b4a2-65dd8c854bc5.png)

to jednak utrudnia pierwotny, najczęstszy scenariusz wyboru pojedynczych wartości z listy, gdyż każdy wybór trzeba „odklikać”, żeby wybrać nowy pojedynczy.

![image](https://user-images.githubusercontent.com/25225728/177477919-1e24c174-441c-43b8-9bab-060a7260404e.png)


Closes #746.