### PR TITLE
Przywrócenie widoczności wszystkich prac dyplomowych dla administratorów

### DIFF
--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -43,7 +43,7 @@ class ThesesSystemSettings(models.Model):
 
 class ThesesQuerySet(models.QuerySet):
     def visible(self, user):
-        if is_theses_board_member(user):
+        if user.is_staff or is_theses_board_member(user):
             return self
         return self.filter(
             (~Q(status=ThesisStatus.BEING_EVALUATED) & ~Q(status=ThesisStatus.RETURNED_FOR_CORRECTIONS)) |


### PR DESCRIPTION
Ciąg dalszy #1347: w #1233 kilka rzeczy zostało pochopnie ukrytych przed użytkownikami z uprawnieniami administratora (np. dziekanatem), później widoczność części z nich została przywrócona, ale nie znalazło się wśród nich wyświetlanie wszystkich prac, tj. nadal widoczne były tylko te zaakceptowane przez komisję. Teraz naprawiamy i to przeoczenie, z wiarą i nadzieją, że to już ostatnie.