### PR TITLE
1358 komunikat o niepowodzeniu

### DIFF
--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -112,6 +112,7 @@ def course_view_data(request, slug) -> Tuple[Optional[CourseInstance], Optional[
     }
     return course, data
 
+
 @require_GET
 def course_view(request, slug):
     course, data = course_view_data(request, slug)

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -2,17 +2,21 @@ import csv
 import json
 from typing import Dict, Iterable, List, Optional, Tuple, TypedDict
 
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.views.decorators.http import require_GET
 
 from apps.enrollment.courses.models.course_instance import CourseInstance
 from apps.enrollment.courses.models.group import Group, GuaranteedSpots
 from apps.enrollment.courses.models.semester import Semester
 from apps.enrollment.records.models import Record, RecordStatus
 from apps.enrollment.utils import mailto
+from apps.notifications.repositories import get_notifications_repository
+from apps.notifications.utils import render_description
 from apps.users.decorators import employee_required
 from apps.users.models import Student, is_external_contractor
 
@@ -108,12 +112,23 @@ def course_view_data(request, slug) -> Tuple[Optional[CourseInstance], Optional[
     }
     return course, data
 
-
+@require_GET
 def course_view(request, slug):
     course, data = course_view_data(request, slug)
     if course is None:
         raise Http404
     data.update(prepare_courses_list_data(course.semester))
+
+    notification_id = request.GET.get("notification")
+    if notification_id and request.user:
+        notifications_repository = get_notifications_repository()
+        notification = notifications_repository.get_by_id(
+            request.user, notification_id)
+        if notification:
+            description = render_description(notification.description_id,
+                                             notification.description_args)
+            messages.warning(request, description)
+
     return render(request, 'courses/courses.html', data)
 
 

--- a/zapisy/apps/enrollment/records/views.py
+++ b/zapisy/apps/enrollment/records/views.py
@@ -29,11 +29,12 @@ def enqueue(request):
                 "asynchroniczny proces."
             )
         )
-        if not Record.can_enroll(student, group):
+        if not (reason := Record.can_enroll(student, group)):
             messages.warning(request,
                              ("W tym momencie nie spełniasz kryteriów zapisu do tej grupy. "
-                              "Jeśli nie  zmieni się to do czasu wciągania Twojego rekordu "
-                              "z  kolejki, zostanie on usunięty."))
+                              "Powód: " + reason.value + ". "
+                              "Jeśli nie zmieni się to do czasu wciągania Twojego rekordu "
+                              "z kolejki, zostanie on usunięty."))
     else:
         messages.warning(request, "Nie udało się dopisać do kolejki.")
     return redirect('course-page', slug=group.course.slug)

--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -130,7 +130,10 @@ export default class NotificationsComponent extends Vue {
                 &times;
               </button>
             </div>
-            <a :href="elem.target" class="toast-link">
+            <a
+              :href="elem.target + '?notification=' + elem.id"
+              class="toast-link"
+            >
               <div class="toast-body text-body">{{ elem.description }}</div>
             </a>
           </div>

--- a/zapisy/apps/notifications/repositories.py
+++ b/zapisy/apps/notifications/repositories.py
@@ -12,6 +12,10 @@ from apps.notifications.serialization import JsonNotificationSerializer, Notific
 class NotificationsRepository(ABC):
 
     @abstractmethod
+    def get_by_id(self, user: User, id: str) -> Notification:
+        pass
+
+    @abstractmethod
     def get_count_for_user(self, user: User) -> int:
         pass
 
@@ -54,6 +58,16 @@ class RedisNotificationsRepository(NotificationsRepository):
         self.serializer = serializer
         self.redis_client = redis.Redis()
         self.removed_count = 0
+
+    def get_by_id(self, user: User, id: str) -> Notification:
+        serialized = self.redis_client.smembers(
+            self._generate_unsent_key_for_user(user))
+        serialized = serialized.union(
+            self.redis_client.smembers(self._generate_sent_key_for_user(user)))
+
+        for notification in map(self.serializer.deserialize, serialized):
+            if notification.id == id:
+                return notification
 
     def get_count_for_user(self, user: User) -> int:
         # SCARD returns 0 if one of them does not exist


### PR DESCRIPTION
(Work in progress!)

Wstępna propozycja rozwiązania dodaje parametr 'notification' do url'a pod który kierowany użytkownik po kliknięciu na powiadomienie. Zawiera on id powiadomienia (może lepsza nazwa to 'notification_id'?). Dodałem jego obsługę w przypadku wyświetlania strony przedmiotu. Powiadomienie wyciągane jest z bazy po id, a jego opis wyświetlany jest w postaci alertu.

Pierwszą rzeczą którą jeszcze chciałbym dodać, to wyświetlanie innego rodzaju alertu w zależności od powiadomienia (nie zawsze chcemy żeby to był warning) i umieścić logikę obsługi parametru 'notification' w lepszym miejscu niż w courses/view.py.

Nie przekonałem też jeszcze sam siebie do pomysłu z doklejaniem parametru do url. zdaje się że "target" powiadomienia może być dowolny, więc ciężko będzie kontrolować czy przypadkiem w nim taki parametr nie będzie już miał innej semantyki, albo pamiętać o dodaniu jego obsługi w każdym miejscu gdzie będzie to potrzebne (sam pewnie tego jeszcze nie zrobiłem).