### PR TITLE
Załatanie scenariusza prowadzącego do TypeErrora w SemesterAdmin.refresh_opening_times #1350

### DIFF
--- a/zapisy/apps/enrollment/courses/admin.py
+++ b/zapisy/apps/enrollment/courses/admin.py
@@ -59,7 +59,14 @@ class SemesterAdmin(admin.ModelAdmin):
         if queryset.count() != 1:
             self.message_user(request, "Trzeba wybrać pojedynczy semestr!", level=messages.ERROR)
             return
+
         semester = queryset.get()
+        if semester.records_opening is None:
+            self.message_user(
+                    request, "Proszę uzupelnić szczegóły odpowiedniego semestru.",
+                    level=messages.ERROR)
+            return
+
         T0Times.populate_t0(semester)
         GroupOpeningTimes.populate_opening_times(semester)
         self.message_user(request,


### PR DESCRIPTION
Przeniesienie całej logiki związanej ze sprawdzeniem użyteczności semestru (nie jest `None` oraz jego atrybut `records_opening` nie jest `None`) do ciała metody `T0Times.populate_t0` nie jest możliwe, ponieważ klasa `T0Times` nie dziedziczy po `AdminModel`, co uniemożliwia wyświetlanie odpowiednich komunikatów błędów. Z tego powodu dodałem niezbędne sprawdzenie w ciele metody `SemesterAdmin.refresh_opening_times`. W tym przypadku mamy pewność, że semestr nie ma wartości `None`, ponieważ jest on wybierany z listy już istniejących semestrów, zatem wystarczy sprawdzić jedynie atrybut `records_opening`.