### PR TITLE
Zmiana definicji zarezerwowanej pracy dyplomowej

### DIFF
--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -131,10 +131,10 @@ class Thesis(models.Model):
 
     @property
     def is_reserved(self):
-        return ((self.reserved_until and (self.students.exists() and
+        return self.students.exists() and ((self.reserved_until and 
                 (self.status == ThesisStatus.DEFENDED
-                or date.today() <= self.reserved_until)))
-                or (self.students.exists() and not self.reserved_until))
+                or date.today() <= self.reserved_until))
+                or (not self.reserved_until))
 
     @property
     def has_been_accepted(self):

--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -131,9 +131,9 @@ class Thesis(models.Model):
 
     @property
     def is_reserved(self):
-        return self.students.exists() and ((self.reserved_until and 
-                (self.status == ThesisStatus.DEFENDED
-                or date.today() <= self.reserved_until))
+        return self.students.exists() and ((self.reserved_until and
+                (date.today() <= self.reserved_until
+                or self.status == ThesisStatus.DEFENDED))
                 or (not self.reserved_until))
 
     @property

--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -131,9 +131,9 @@ class Thesis(models.Model):
 
     @property
     def is_reserved(self):
-        return ((self.reserved_until and (self.students.exists() and 
-                (self.status == ThesisStatus.DEFENDED 
-                or date.today() <= self.reserved_until))) 
+        return ((self.reserved_until and (self.students.exists() and
+                (self.status == ThesisStatus.DEFENDED
+                or date.today() <= self.reserved_until)))
                 or (self.students.exists() and not self.reserved_until))
 
     @property

--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -131,7 +131,10 @@ class Thesis(models.Model):
 
     @property
     def is_reserved(self):
-        return self.reserved_until and date.today() <= self.reserved_until
+        return ((self.reserved_until and (self.students.exists() and 
+                (self.status == ThesisStatus.DEFENDED 
+                or date.today() <= self.reserved_until))) 
+                or (self.students.exists() and not self.reserved_until))
 
     @property
     def has_been_accepted(self):


### PR DESCRIPTION
Zmieniona została definicja zarezerwowanej pracy dyplomowej. Po nałożeniu filtra "pokaż tylko niezarezerwowane prace" nie powinny się już pokazywać prace obronione i prace z przypisaną osobą i bez przypisanego czasu rezerwacji.