### PR TITLE
Wyświetlaj poprawną liczbę osób w kolejce na stronie przedmiotu 

### DIFF
--- a/zapisy/apps/enrollment/records/models/records.py
+++ b/zapisy/apps/enrollment/records/models/records.py
@@ -282,8 +282,9 @@ class Record(models.Model):
         """
         enrolled_agg = models.Count('id', filter=models.Q(status=RecordStatus.ENROLLED))
         enqueued_agg = models.Count('id', filter=models.Q(status=RecordStatus.QUEUED))
-        records = cls.objects.filter(group__in=groups).exclude(
-            status=RecordStatus.REMOVED).values('group_id').annotate(
+        records_distinct = cls.objects.filter(group__in=groups).exclude(
+            status=RecordStatus.REMOVED).distinct('student_id', 'group_id')
+        records = cls.objects.filter(id__in=records_distinct).values('group_id').annotate(
                 num_enrolled=enrolled_agg, num_enqueued=enqueued_agg).values(
                     'group_id', 'num_enrolled', 'num_enqueued')
         ret_dict: Dict[int, Dict[str, int]] = {


### PR DESCRIPTION
Dodaje do zapytania zliczającego liczbę osób w grupie metodę `distinct()`, która przydziela do danej grupy danego studenta tylko raz, zapobiegając w ten sposób policzeniu dwa razy studenta, którego rekord o byciu w kolejce nie został usunięty po zapisaniu do grupy.