### PR TITLE
1416 Rozjeżdżanie tabeli na stronie zarządzania rezerwacjami

### DIFF
--- a/zapisy/apps/schedule/templates/schedule/includes/reservation_view.html
+++ b/zapisy/apps/schedule/templates/schedule/includes/reservation_view.html
@@ -1,4 +1,4 @@
-<table class="table border">
+<table class="table border text-break">
     <tbody>
         <tr>
             <th class="text-light bg-info">Tytuł</th>


### PR DESCRIPTION
Zbyt długie słowo w opisie rezerwacji powoduje zepsucie layoutu strony w zakładce sale/zarządzaj.
Fix dodaje do tabelki bootstrapową klasę [text-break](https://getbootstrap.com/docs/4.3/utilities/text/#word-break), który spowoduje łamanie zbyt długich słów.

![324327880_1318142402360994_3105638496161946660_n](https://user-images.githubusercontent.com/58264216/215602910-9b2f28a0-c775-4053-8878-3d6ad3ed7eb7.png)
![327925225_761651825484090_1229892415972136349_n](https://user-images.githubusercontent.com/58264216/215602928-94ee74a1-38b5-4c57-a9ae-fa2a07083631.png)

