### PR TITLE
1352 Obsługa sytuacji doprowadzającej do kolizji slugów

### DIFF
--- a/zapisy/apps/schedulersync/scheduler_mapper.py
+++ b/zapisy/apps/schedulersync/scheduler_mapper.py
@@ -152,16 +152,25 @@ class SchedulerMapper:
                                     "the course proposal in the database.\n"
                                     "Type 'None' to mark the course to be ignored.".format(error, name))
 
-        def get_course(proposal: 'Proposal') -> 'CourseInstance':
+        def get_course(proposal: 'Proposal', course_name: 'str', interactive: bool = True) -> 'CourseInstance':
             """Return CourseInstance object from SZ database."""
             course = None
             try:
                 course = CourseInstance.objects.get(semester=self.semester, offer=proposal)
                 self.summary.used_courses += 1
             except CourseInstance.DoesNotExist:
-                course = CourseInstance.create_proposal_instance(proposal, self.semester)
-                self.summary.created_courses += 1
-                print(f"+ Course instance '{proposal.name}' created")
+                existing_course = CourseInstance.objects.filter(semester=self.semester, name=course_name)
+                if not existing_course:
+                    course = CourseInstance.create_proposal_instance(proposal, self.semester)
+                    self.summary.created_courses += 1
+                    print(f"+ Course instance '{proposal.name}' created")
+                elif interactive:
+                    existing_proposal = existing_course.get().proposal
+                    print(
+                        f"Course {course_name} has created CourseInstance object for proposal: {existing_proposal}. "
+                        f"Skiping create new CourseInsatnce object for proposal: {proposal}. "
+                        "Please fix it."
+                    )
             return course
 
         mapped_courses = {}
@@ -170,7 +179,7 @@ class SchedulerMapper:
             if proposal is None:
                 mapped_courses[course] = None
             else:
-                mapped_courses[course] = get_course(proposal)
+                mapped_courses[course] = get_course(proposal, course, self.interactive_flag)
         return mapped_courses
 
     def _map_classrooms(self, rooms: Iterable[str]) -> Dict[str, Classroom]:


### PR DESCRIPTION
https://github.com/iiuni/projektzapisy/issues/1352

Kolizja slugów mogła wystąpić w przypadku gdy podczas importowania planu z Schedulera importowaliśmy ten sam przedmiot wielokrotnie z wykorzystaniem różnych propozycji przedmiotu. Na tą chwilę, podczas synchronizowania planu z Schedulera ze stanem bazy, następuje sprawdzenie czy przed utworzeniem nowego obiektu `CourseInstance` nie nastąpi kolizja. W przypadku jej wystąpienia funkcja [`get_course(...)`](https://github.com/iiuni/projektzapisy/blob/290dcd8f6e78be7b7063914c3873fc01501bc992/zapisy/apps/schedulersync/scheduler_mapper.py#L155) zwraca `None` oraz dodatkowo w trybie interaktywnym printowany jest odpowiedni komunikat.