### PR TITLE
Naprawiono API CompletedCourses

### DIFF
--- a/zapisy/apps/api/rest/v1/serializers.py
+++ b/zapisy/apps/api/rest/v1/serializers.py
@@ -233,20 +233,6 @@ class RecordSerializer(serializers.ModelSerializer):
         fields = ('id', 'group', 'student')
 
 
-class CourseRelatedField(serializers.RelatedField):
-    def display_value(self, instance):
-        return instance
-
-    def to_representation(self, value):
-        return value.usos_kod
-
-    def to_internal_value(self, data):
-        try:
-            return CourseInstance.objects.get(usos_kod=data)
-        except CourseInstance.DoesNotExist:
-            raise serializers.ValidationError("Kurs o podanym usos_kod nie istnieje.")
-
-
 class StudentRelatedField(serializers.RelatedField):
     def display_value(self, instance):
         return instance
@@ -262,12 +248,7 @@ class StudentRelatedField(serializers.RelatedField):
 
 
 class CompletedCoursesSerializer(serializers.ModelSerializer):
-    """Serializes a CompletedCourses record.
-
-    StudentRelatedField and CourseRelatedField enable the API to use
-    usos_id and usos_kod to represent student and course fields in CompletedCourses
-    instead of internal django ids while also validating the input
-    """
+    """Serializes a CompletedCourses record."""
     student = StudentRelatedField(queryset=Student.objects.filter(is_active=True))
     program = ProgramRelatedField(queryset=Program.objects.all())
     course = CourseSerializer()


### PR DESCRIPTION
Problem jest opisany po krótce w podlinkowanym issue. 

Proponowane rozwiązanie zakłada usunięcie wadliwego CourseRelatedField i zastąpienie go CourseSerializerem gdzie mogliśmy wykorzystać powiązane pole z semestrem, stąd mamy odrazu walidację wyboru tego semestru. 

Dodatkowo chcemy instancje kursu identyfikować poprzez jego usos kod, tu zostawiłem pole tekstowe do wpisania kodu. Cały wybór jest jeszcze sprawdzany w metodzie create, gdzie na wypadek problemu wznosimy wyjątek. 

Podsumowując, obecny formularz do wstawiania nowych rekordów prezentuje się tak:
![obraz](https://user-images.githubusercontent.com/58195100/220408049-1f7ce4f6-0f99-4755-a46b-f84bff75d0a0.png)

A oto przykładowe dane po wstawieniu:
![obraz](https://user-images.githubusercontent.com/58195100/220408151-9a01e6d9-6afe-4a0c-bb3f-64251f3dfc28.png)
