### PR TITLE
Filtr niezarezerwowane prace -> dostępne prace

### DIFF
--- a/zapisy/apps/theses/assets/components/ThesisFilter.vue
+++ b/zapisy/apps/theses/assets/components/ThesisFilter.vue
@@ -66,7 +66,7 @@ export default Vue.extend({
           <CheckFilter
             filterKey="available-filter"
             property="is_available"
-            label="Pokaż tylko dostępne tematy"
+            label="Pokaż tylko niezarezerwowane prace"
           />
         </div>
         <div class="col-lg-4">

--- a/zapisy/apps/theses/assets/components/ThesisFilter.vue
+++ b/zapisy/apps/theses/assets/components/ThesisFilter.vue
@@ -66,7 +66,7 @@ export default Vue.extend({
           <CheckFilter
             filterKey="available-filter"
             property="is_available"
-            label="Pokaż tylko niezarezerwowane prace"
+            label="Pokaż tylko dostępne tematy"
           />
         </div>
         <div class="col-lg-4">

--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -134,6 +134,11 @@ class Thesis(models.Model):
         return self.reserved_until and date.today() <= self.reserved_until
 
     @property
+    def is_available(self):
+        is_defended = self.status == ThesisStatus.DEFENDED
+        return not (self.is_reserved or is_defended)
+
+    @property
     def has_been_accepted(self):
         return self.status != ThesisStatus.RETURNED_FOR_CORRECTIONS and self.status != ThesisStatus.BEING_EVALUATED
 

--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -134,6 +134,10 @@ class Thesis(models.Model):
         return self.reserved_until and date.today() <= self.reserved_until
 
     @property
+    def is_available(self):
+        return self.has_no_students_assigned
+
+    @property
     def has_been_accepted(self):
         return self.status != ThesisStatus.RETURNED_FOR_CORRECTIONS and self.status != ThesisStatus.BEING_EVALUATED
 

--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -134,10 +134,6 @@ class Thesis(models.Model):
         return self.reserved_until and date.today() <= self.reserved_until
 
     @property
-    def is_available(self):
-        return self.has_no_students_assigned
-
-    @property
     def has_been_accepted(self):
         return self.status != ThesisStatus.RETURNED_FOR_CORRECTIONS and self.status != ThesisStatus.BEING_EVALUATED
 

--- a/zapisy/apps/theses/views.py
+++ b/zapisy/apps/theses/views.py
@@ -25,7 +25,7 @@ def list_all(request):
     theses_list = []
     for p in visible_theses:
         title = p.title
-        is_available = p.is_available
+        is_available = not p.is_reserved
         kind = p.get_kind_display()
         status = p.get_status_display()
         is_mine = p.is_mine(request.user) or p.is_student_assigned(

--- a/zapisy/apps/theses/views.py
+++ b/zapisy/apps/theses/views.py
@@ -25,7 +25,7 @@ def list_all(request):
     theses_list = []
     for p in visible_theses:
         title = p.title
-        is_available = not p.is_reserved
+        is_available = p.is_available
         kind = p.get_kind_display()
         status = p.get_status_display()
         is_mine = p.is_mine(request.user) or p.is_student_assigned(


### PR DESCRIPTION
Zastępuje filtr "Pokaż tylko niezarezerwowane prace" przez "Pokaż tylko dostępne tematy". Stary filtr był nieczytelny dla użytkowników - po jego zaznaczeniu pozostawały zarezerwowane prace, których rezerwacje wygasły (nawet te już obronione!). Po zmianie filtr pokazuje tylko prace, do których nie ma przypisanego żadnego studenta.

Rozwiązuje #1335 
