### PR TITLE
Usunięcie `postmarkup` z zależności Pythona

### DIFF
--- a/zapisy/requirements.common.txt
+++ b/zapisy/requirements.common.txt
@@ -25,8 +25,6 @@ python-dateutil==2.8.2
 python-memcached==1.59
 more-itertools==8.14.0
 xhtml2pdf==0.2.9
-# BBCode -> HTML
-postmarkup==1.2.2
 # PyYAML is used for fixtures.
 pyyaml==5.4.1
 # Bokeh - library used for plotting in views displaying Poll results


### PR DESCRIPTION
Poprawka usuwa z `requirements.common.txt` pakiet, który przestał być rozwijany osiem lat temu, odwołania do niego w projekcie zniknęły trzy lata temu (realnie mógł przestać być używany jeszcze wcześniej), a niedawno przestała być możliwa jego instalacja w związku ze zmianami w bibliotece `setuptools`.