### PR TITLE
Sprawdzanie przypisania oferty do przedmiotu przed wyświetleniem przycisku "Edytuj"

### DIFF
--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -8,7 +8,7 @@
     <div class="btn-group" role="group" aria-label="Basic example">
         <a class="btn btn-sm btn-outline-info float-right align-bottom" href="{% url 'course-student-list' course.slug %}">Lista</a>
         {% if user.is_staff or course.owner == request.user.employee %}
-            {% if course.semester.is_current_semester %}
+            {% if course.semester.is_current_semester and course.offer %}
                 <a class="btn btn-sm btn-outline-info float-right align-bottom" href="{% url 'proposal-edit' course.offer.slug %}">Edytuj</a>
             {% endif %}
         {% endif %}


### PR DESCRIPTION
Obecnie template `course_head` z aplikacji `courses` wyświetla przycisk "Edytuj" niezależnie od tego, czy dany przedmiot ma przypisaną ofertę, co może prowadzić do błędów takich jak w https://github.com/iiuni/projektzapisy/issues/1142.

Problem został rozwiązany przez aktualizację jednej z instrukcji warunkowych template'u.