### PR TITLE
Poprawna walidacja wszystkich pól formularza PreferenceForm

### DIFF
--- a/zapisy/apps/offer/preferences/forms.py
+++ b/zapisy/apps/offer/preferences/forms.py
@@ -9,10 +9,21 @@ from .models import Preference
 class PreferenceForm(forms.ModelForm):
     class Meta:
         model = Preference
-        fields = ('answer',)
+        fields = ('answer', 'question', 'employee')
         labels = {
             'answer': "",
         }
+
+    def __init__(self, *args, **kwargs):
+        """Mark emplayee and question fields as hidden in the html.
+
+        Now received values of these fields will be properly checked in is_valid.
+        This will prevent null value insertion attempts if variables controlling the formset on the fornt-end
+        are manipulated.
+        """
+        super().__init__(*args, **kwargs)
+        self.fields['employee'].widget = forms.HiddenInput()
+        self.fields['question'].widget = forms.HiddenInput()
 
 
 def prepare_formset(employee: Employee, post=None):

--- a/zapisy/apps/offer/preferences/views.py
+++ b/zapisy/apps/offer/preferences/views.py
@@ -15,8 +15,12 @@ def main(request):
         if formset.is_valid():
             formset.save()
             messages.info(request, "Zapisano głos.")
+        else:
+            # note: this is a temporary diagnostic message.
+            messages.error(request, f"A validation error has occured - please reload the app.")
     else:
         formset = prepare_formset(employee)
+        messages.info(request, formset.initial_form_count())
 
     return render(request, 'preferences/main.html', {
         'formset': formset,


### PR DESCRIPTION
Dodanie pól `question` oraz `employee` do formularza `PreferenceForm` i manualne nadanie im reprezentacji input hidden powoduje, że nie generowany jest już wyjątek.

Nie rozwiązuje to natomiast istoty problemu czyli tego, że `formset'y pozwalają na równoczesną modyfikację danych i dodawanie nowych. Parametry kontrolujące to, które formularze dodają nowe, a które modyfikują istniejące instancje modeli są na domiar złego dostępne w DOM'ie ([dokładniejsze wyjaśnienie](https://github.com/iiuni/projektzapisy/issues/1322#issuecomment-1584903333)). Rozwiązaniem problemu byłoby uniemożliwienie wymuszenia tworzenia nowych instancji, co z moich ustaleń nie jest wspierane bibliotecznie. 

Można stworzyć natomiast nową klasę / dekorator ~ `ViewFormSet`, która będzie służyła tylko i wyłącznie modyfikacji istniejących danych. **Wydaje mi się**, że można to osiągnąć poprzez napisanie metody `save_new_objects` w klasie `BaseModelFormSet`. Dodatkowo `modelformset_factory` wydaje się wspierać wstrzykiwanie klasy bazowej:

```python
def modelformset_factory(model, form=ModelForm, formfield_callback=None,
                         formset=BaseModelFormSet, #  <--- Tutaj wstrzykniemy naszą klasę niepozwalającą na dodawanie nowych danych
                         extra=1, can_delete=False,
                         can_order=False, max_num=None, fields=None, exclude=None,
                         widgets=None, validate_max=False, localized_fields=None,
                         labels=None, help_texts=None, error_messages=None,
                         min_num=None, validate_min=False, field_classes=None):
```

Proszę się nie dać zwieść fajnie brzmiącym parametrom `max_num` / `min_num` oraz `validate_max` / `validate_min`. Pierwsze z nich można właśnie nadpisać w DOM'ie a drugie tylko aktywują sprawdzanie ilości.