### PR TITLE
Linter domaga się atencji, więc mu ją dajemy

### DIFF
--- a/zapisy/apps/api/rest/v1/api_wrapper/sz_api/models.py
+++ b/zapisy/apps/api/rest/v1/api_wrapper/sz_api/models.py
@@ -9,7 +9,7 @@ class Model:
 
     @classmethod
     def from_dict(cls, obj):
-        if type(obj) == cls or obj is None:
+        if type(obj) is cls or obj is None:
             return obj
         try:
             return cls(**obj)


### PR DESCRIPTION
Z jakiegoś powodu `flake8` wywoływany przez _workflow_ "lint" w GitHub Actions postanowił dopiero w tym miesiącu zobaczyć problem w kodzie powstałym (zgodnie z `git blame`) w 2020. Można by się domyślać, że to przez pojawienie się nowej wersji lintera w repozytoriach `pip`, ale reguła E721 była komentowana w Internecie już w 2018…

Niezależnie od dokładnych przyczyn, po zaaplikowanej kosmetycznej zmianie, akcje znów przechodzą bez problemów (na razie).