### PR TITLE
Wybór semestru w widoku planu zajęć

### DIFF
--- a/zapisy/apps/enrollment/timetable/templates/timetable/timetable.html
+++ b/zapisy/apps/enrollment/timetable/templates/timetable/timetable.html
@@ -19,39 +19,69 @@
 
 
 {% block all-content %}
-    <p class="text-right">
-        <a class="btn btn-sm btn-light" href="{% url 'calendar-export' %}">
-            <i class="fa fa-calendar-alt"></i> Eksportuj plan zajęć</a>
-    </p>
+    <div class="row my-4">
+        <div class="col-lg-9 col-12 order-last order-lg-first">
+            {% if semester.is_current_semester %}
+                <p class="text-right">
+                    <a class="btn btn-sm btn-light" href="{% url 'calendar-export' %}">
+                        <i class="fa fa-calendar-alt"></i> Eksportuj plan zajęć
+                    </a>
+                </p>
+            {% endif %}
+        </div>
+        <nav class="col-lg-3 col-12 d-print-none order-first order-lg-last mb-3">
+            <div class="dropdown">
+                <div class="btn-group btn-block mb-3">
+                    <button class="btn btn-light" disabled>
+                        <strong>Semestr {{ semester }}</strong>
+                    </button>
+                    <button class="btn btn-light dropdown-toggle dropdown-toggle-split"
+                            href="#" role="button" id="semester-dropdown" 
+                            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span class="sr-only"></span>
+                    </button>
+                    <div class="dropdown-menu" aria-labelledby="semester-dropdown">
+                        {% for semester in all_semesters %}
+                            <a class="dropdown-item semester-link"
+                                    href={% url 'my-timetable-semester' semester.pk %}>
+                                {{ semester }}
+                            </a>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </div>
+
     <div class="row m-0" id="timetable">
     </div>
     {{ groups_dicts|json_script:"timetable-data" }}
     {% render_bundle 'timetable-timetable-component' %}
     
     {% if user.student %}
-    <h3>{% trans "Zajęcia, na które jesteś zapisany" %}</h3>
+    <h3>Twoje przedmioty</h3>
     <div class="table-responsive">
-	<table id="enr-schedule-listByCourse" class="table table-striped">
-		<thead>
-			<tr>
+    <table id="enr-schedule-listByCourse" class="table table-striped">
+        <thead>
+            <tr>
                 {# Translators: Tytuł kolumny w tabelce #}
-				<th scope="col">{% trans "Przedmiot" %}</th>
-				{% if user.student %}
+                <th scope="col">{% trans "Przedmiot" %}</th>
+                {% if user.student %}
                     {# Translators: Tytuł kolumny w tabelce #}
                     <th class="ects" scope="col">{% trans "ECTS" %}</th>
                 {% else %}
                     {# Translators: Tytuł kolumny w tabelce #}
                     <th class="ects" scope="col">{% trans "Godziny" %}</th>
                 {% endif %}
-			</tr>
-		</thead>
-		<tfoot>
-			<tr>
+            </tr>
+        </thead>
+        <tfoot>
+            <tr>
                 <td><strong>Suma punktów ECTS:</strong></td>
                 <td class="ects">{{ sum_points }}</td>
-			</tr>
-		</tfoot>
-		<tbody>
+            </tr>
+        </tfoot>
+        <tbody>
             {% regroup groups|dictsort:"course_id" by course as courses %}
             {% for course in courses %}
             <tr class="courseHeader">
@@ -90,7 +120,7 @@
                 </td>
             </tr>
             {% endfor %}
-		</tbody>
+        </tbody>
     </table>
     </div>  
     {% endif %}

--- a/zapisy/apps/enrollment/timetable/urls.py
+++ b/zapisy/apps/enrollment/timetable/urls.py
@@ -4,6 +4,7 @@ from apps.enrollment.timetable import views
 
 urlpatterns = [
     path('', views.my_timetable, name='my-timetable'),
+    path('semester/<int:semester_id>/', views.my_timetable, name='my-timetable-semester'),
     path('prototype/', views.my_prototype, name='my-prototype'),
     path('prototype/action/<int:group_id>/', views.prototype_action, name='prototype-action'),
     path('prototype/course/<int:course_id>/', views.prototype_get_course, name='prototype-get-course'),

--- a/zapisy/apps/enrollment/timetable/views.py
+++ b/zapisy/apps/enrollment/timetable/views.py
@@ -2,13 +2,13 @@
 import collections
 import csv
 import json
-from typing import List
+from typing import List, Optional
 
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count, Q
 from django.forms.models import model_to_dict
 from django.http import JsonResponse
-from django.shortcuts import Http404, HttpResponse, render
+from django.shortcuts import Http404, HttpResponse, get_object_or_404, render
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 
@@ -84,9 +84,9 @@ def list_courses_in_semester(semester: Semester):
     return courses
 
 
-def student_timetable_data(student: Student):
+def student_timetable_data(student: Student, semester: Optional[Semester]):
     """Collects the timetable data for a student."""
-    semester = Semester.get_current_semester()
+    all_semesters = Semester.objects.filter(visible=True)
     # This costs an additional join, but works if there is no current semester.
     records = Record.objects.filter(
         student=student,
@@ -100,6 +100,8 @@ def student_timetable_data(student: Student):
     points_for_courses = {r.group.course.id: r.group.course.points for r in records}
 
     data = {
+        'semester': semester,
+        'all_semesters': all_semesters,
         'groups': groups,
         'sum_points': sum(points_for_courses.values()),
         'groups_dicts': group_dicts,
@@ -107,29 +109,36 @@ def student_timetable_data(student: Student):
     return data
 
 
-def employee_timetable_data(employee: Employee):
+def employee_timetable_data(employee: Employee, semester: Optional[Semester]):
     """Collects the timetable data for an employee."""
-    semester = Semester.get_current_semester()
+    all_semesters = Semester.objects.filter(visible=True)
     groups = Group.objects.filter(teacher=employee, course__semester=semester).select_related(
         'teacher', 'teacher__user', 'course').prefetch_related(
             'term', 'term__classrooms', 'guaranteed_spots', 'guaranteed_spots__role')
     group_dicts = build_group_list(groups)
     data = {
+        'semester': semester,
+        'all_semesters': all_semesters,
         'groups_dicts': group_dicts,
     }
     return data
 
 
 @login_required
-def my_timetable(request):
+def my_timetable(request, semester_id: Optional[int] = None):
     """Shows the student/employee his own timetable page."""
     # Counter will add elements key-wise. Numbers will be added, lists will be
     # extended.
+    semester: Optional[Semester]
+    if semester_id is None:
+        semester = Semester.get_current_semester()
+    else:
+        semester = get_object_or_404(Semester, pk=semester_id)
     data = collections.Counter()
     if request.user.student:
-        data.update(student_timetable_data(request.user.student))
+        data.update(student_timetable_data(request.user.student, semester))
     if request.user.employee:
-        data.update(employee_timetable_data(request.user.employee))
+        data.update(employee_timetable_data(request.user.employee, semester))
 
     return render(request, 'timetable/timetable.html', data)
 


### PR DESCRIPTION
Umożliwiamy wyświetlanie planu zajęć dla semestrów innych niż bieżący przez drobną modyfikację istniejących widoków, dodanie nowego _URL pattern_ oraz umieszczenie w szablonie kontrolki ~~ukradzionej~~ z podstron `/courses/`. (Przy okazji pozbywamy się znaków tabulacji z szablonu jako jednego z nielicznych plików źródłowych projektu, które je zawierają.)