### PR TITLE
Sortowanie grup zajęciowych

### DIFF
--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -76,9 +76,9 @@ def course_view_data(request, slug) -> Tuple[Optional[CourseInstance], Optional[
         student = request.user.student
 
     groups = course.groups.select_related(
-        'teacher',
-        'teacher__user',
-    ).prefetch_related('term', 'term__classrooms', 'guaranteed_spots', 'guaranteed_spots__role'
+        'teacher', 'teacher__user',
+    ).prefetch_related(
+        'term', 'term__classrooms', 'guaranteed_spots', 'guaranteed_spots__role'
     ).order_by('term__dayOfWeek', 'term__start_time', 'teacher__user__first_name', 'teacher__user__last_name')
 
     # Collect the general groups statistics.

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -78,16 +78,8 @@ def course_view_data(request, slug) -> Tuple[Optional[CourseInstance], Optional[
     groups = course.groups.select_related(
         'teacher',
         'teacher__user',
-    ).prefetch_related('term', 'term__classrooms', 'guaranteed_spots', 'guaranteed_spots__role')
-
-    def group_sort_key(group):
-        first_term = group.term.first()
-        day_nr = first_term.day_in_zero_base()
-        start_time = first_term.time_from()
-        teacher_name = str(group.teacher)
-        return (day_nr, start_time, teacher_name)
-
-    groups = sorted(groups, key=group_sort_key)
+    ).prefetch_related('term', 'term__classrooms', 'guaranteed_spots', 'guaranteed_spots__role'
+    ).order_by('term__dayOfWeek', 'term__start_time', 'teacher__user__first_name', 'teacher__user__last_name')
 
     # Collect the general groups statistics.
     groups_stats = Record.groups_stats(groups)

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -80,7 +80,7 @@ def course_view_data(request, slug) -> Tuple[Optional[CourseInstance], Optional[
         'teacher', 'teacher__user',
     ).prefetch_related(
         'term', 'term__classrooms', 'guaranteed_spots', 'guaranteed_spots__role'
-    ).alias(
+    ).annotate(
         earliest_dayOfWeek=Min('term__dayOfWeek'), earliest_start_time=Min('term__start_time')
     ).order_by(
         'earliest_dayOfWeek', 'earliest_start_time', 'teacher__user__last_name', 'teacher__user__first_name'

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -3,9 +3,9 @@ import json
 import locale
 from typing import Dict, Iterable, List, Optional, Tuple, TypedDict
 
-from django.db.models import Min
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+from django.db.models import Min
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -3,6 +3,7 @@ import json
 import locale
 from typing import Dict, Iterable, List, Optional, Tuple, TypedDict
 
+from django.db.models import Min
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.http import Http404, HttpResponse
@@ -79,7 +80,11 @@ def course_view_data(request, slug) -> Tuple[Optional[CourseInstance], Optional[
         'teacher', 'teacher__user',
     ).prefetch_related(
         'term', 'term__classrooms', 'guaranteed_spots', 'guaranteed_spots__role'
-    ).order_by('term__dayOfWeek', 'term__start_time', 'teacher__user__first_name', 'teacher__user__last_name')
+    ).annotate(
+        earliest_dayOfWeek=Min('term__dayOfWeek'), earliest_start_time=Min('term__start_time')
+    ).order_by(
+        'earliest_dayOfWeek', 'earliest_start_time', 'teacher__user__last_name', 'teacher__user__first_name'
+        )
 
     # Collect the general groups statistics.
     groups_stats = Record.groups_stats(groups)

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -80,7 +80,7 @@ def course_view_data(request, slug) -> Tuple[Optional[CourseInstance], Optional[
         'teacher', 'teacher__user',
     ).prefetch_related(
         'term', 'term__classrooms', 'guaranteed_spots', 'guaranteed_spots__role'
-    ).annotate(
+    ).alias(
         earliest_dayOfWeek=Min('term__dayOfWeek'), earliest_start_time=Min('term__start_time')
     ).order_by(
         'earliest_dayOfWeek', 'earliest_start_time', 'teacher__user__last_name', 'teacher__user__first_name'

--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -80,6 +80,15 @@ def course_view_data(request, slug) -> Tuple[Optional[CourseInstance], Optional[
         'teacher__user',
     ).prefetch_related('term', 'term__classrooms', 'guaranteed_spots', 'guaranteed_spots__role')
 
+    def group_sort_key(group):
+        first_term = group.term.first()
+        day_nr = first_term.day_in_zero_base()
+        start_time = first_term.time_from()
+        teacher_name = str(group.teacher)
+        return (day_nr, start_time, teacher_name)
+
+    groups = sorted(groups, key=group_sort_key)
+
     # Collect the general groups statistics.
     groups_stats = Record.groups_stats(groups)
     # Collect groups information related to the student.


### PR DESCRIPTION
Dodaję sortowanie według schematu, który został zaproponowany. Najpierw po porze zajęć, a następnie po personaliach prowadzącego.