### PR TITLE
Dodanie promotora pomocniczego do deklaracji

### DIFF
--- a/zapisy/apps/theses/templates/theses/form_pdf.html
+++ b/zapisy/apps/theses/templates/theses/form_pdf.html
@@ -50,7 +50,7 @@
     <h3>III. Dane pracy</h3>
     <p>Proponowany tytuł pracy: <strong>{{ thesis.title }}</strong></p>
     {% if thesis.reserved_until %}
-        <p>Temat jest zarezerwowany dla ww. studenta/ów do: {{ thesis.reserved_until }}</p>
+        <p>Temat jest zarezerwowany dla ww. studenta/ów do: {{ thesis.reserved_until|date:'d.m.Y' }}</p>
     {% endif %}
     <p>Temat zawiera część programistyczną: <strong>TAK/NIE</strong></p>
     <p>Temat będzie realizowany przez <strong>{{ students_num }}</strong> {% if students_num == 1 %}studenta{% else %}studentów{% endif %}.</p>

--- a/zapisy/apps/theses/templates/theses/form_pdf.html
+++ b/zapisy/apps/theses/templates/theses/form_pdf.html
@@ -3,7 +3,7 @@
     <meta charset="UTF-8" />
     <title>{{ thesis.title }}</title>
     <style>
-      body{
+      body {
         font-size: 12px;
       }
       h1 {
@@ -15,14 +15,14 @@
         font-size: 14px;
         text-align: center;
       }
-      h3{
-          font-size: 13px;
-          text-decoration: underline;
+      h3 {
+        font-size: 13px;
+        text-decoration: underline;
       }
-      p{
-          text-indent: 2em;
-          margin: 0;
-          padding: 0;
+      p {
+        text-indent: 2em;
+        margin: 0;
+        padding: 0;
       }
     </style>
   </head>
@@ -38,14 +38,11 @@
     <h3>I. Dane studenta</h3>
     <p>Imię i nazwisko: <strong>{{ first_student.get_full_name }}</strong></p>
     <p>Numer albumu: <strong>{{ first_student.matricula }}</strong></p>
+    <h3>II{% if thesis.supporting_advisor %}a{% endif %}. Dane promotora</h3>
+    <p>Imię, nazwisko, st. naukowy: <strong>{{ thesis.advisor }}</strong></p>
     {% if thesis.supporting_advisor %}
-      <h3>IIa. Dane promotora</h3>
-      <p>Imię, nazwisko, st. naukowy:  <strong>{{ thesis.advisor }}</strong></p>
       <h3>IIb. Dane promotora wspierającego</h3>
-      <p>Imię, nazwisko, st. naukowy:  <strong>{{ thesis.supporting_advisor }}</strong></p>
-    {% else %}
-      <h3>II. Dane promotora</h3>
-      <p>Imię, nazwisko, st. naukowy:  <strong>{{ thesis.advisor }}</strong></p>
+      <p>Imię, nazwisko, st. naukowy: <strong>{{ thesis.supporting_advisor }}</strong></p>
     {% endif %}
     <h3>III. Dane pracy</h3>
     <p>Proponowany tytuł pracy: <strong>{{ thesis.title }}</strong></p>

--- a/zapisy/apps/theses/templates/theses/form_pdf.html
+++ b/zapisy/apps/theses/templates/theses/form_pdf.html
@@ -38,8 +38,15 @@
     <h3>I. Dane studenta</h3>
     <p>Imię i nazwisko: <strong>{{ first_student.get_full_name }}</strong></p>
     <p>Numer albumu: <strong>{{ first_student.matricula }}</strong></p>
-    <h3>II. Dane promotora</h3>
-    <p>Imię, nazwisko, st. naukowy:  <strong>{{ thesis.advisor }}</strong></p>
+    {% if thesis.supporting_advisor %}
+      <h3>IIa. Dane promotora</h3>
+      <p>Imię, nazwisko, st. naukowy:  <strong>{{ thesis.advisor }}</strong></p>
+      <h3>IIb. Dane promotora pomocniczego</h3>
+      <p>Imię, nazwisko, st. naukowy:  <strong>{{ thesis.supporting_advisor }}</strong></p>
+    {% else %}
+      <h3>II. Dane promotora</h3>
+      <p>Imię, nazwisko, st. naukowy:  <strong>{{ thesis.advisor }}</strong></p>
+    {% endif %}
     <h3>III. Dane pracy</h3>
     <p>Proponowany tytuł pracy: <strong>{{ thesis.title }}</strong></p>
     {% if thesis.reserved_until %}
@@ -61,6 +68,9 @@
     </br></br></br></br></br>
         .................................................................</br>Data i podpis studenta</br></br></br></br></br>
         .................................................................</br>Data i podpis promotora</br></br></br></br></br>
+        {% if thesis.supporting_advisor %}
+          .................................................................</br>Data i podpis promotora pomocniczego</br></br></br></br></br>
+        {% endif %}
     <strong>UWAGA:</strong></br>
     Jeśli zadeklarowana praca nie zostanie złożona w Dziekanacie przed upływem podanego terminu rezerwacji, promotor może odmówić dalszej współpracy przy realizacji tematu oraz może przydzielić temat innej osobie. Do kontynuacji współpracy wymagane jest ponowne złożenie deklaracji.
     </body>

--- a/zapisy/apps/theses/templates/theses/form_pdf.html
+++ b/zapisy/apps/theses/templates/theses/form_pdf.html
@@ -41,7 +41,7 @@
     {% if thesis.supporting_advisor %}
       <h3>IIa. Dane promotora</h3>
       <p>Imię, nazwisko, st. naukowy:  <strong>{{ thesis.advisor }}</strong></p>
-      <h3>IIb. Dane promotora pomocniczego</h3>
+      <h3>IIb. Dane promotora wspierającego</h3>
       <p>Imię, nazwisko, st. naukowy:  <strong>{{ thesis.supporting_advisor }}</strong></p>
     {% else %}
       <h3>II. Dane promotora</h3>
@@ -69,7 +69,7 @@
         .................................................................</br>Data i podpis studenta</br></br></br></br></br>
         .................................................................</br>Data i podpis promotora</br></br></br></br></br>
         {% if thesis.supporting_advisor %}
-          .................................................................</br>Data i podpis promotora pomocniczego</br></br></br></br></br>
+          .................................................................</br>Data i podpis promotora wspierającego</br></br></br></br></br>
         {% endif %}
     <strong>UWAGA:</strong></br>
     Jeśli zadeklarowana praca nie zostanie złożona w Dziekanacie przed upływem podanego terminu rezerwacji, promotor może odmówić dalszej współpracy przy realizacji tematu oraz może przydzielić temat innej osobie. Do kontynuacji współpracy wymagane jest ponowne złożenie deklaracji.


### PR DESCRIPTION
Zmiana dodaje dane promotora pomocniczego (jeśli takowy występuje) do generowanego formularza deklaracji tematu pracy dyplomowej