### PR TITLE
1564 duzy obrazek

### DIFF
--- a/zapisy/apps/common/assets/markdown/render-markdown.scss
+++ b/zapisy/apps/common/assets/markdown/render-markdown.scss
@@ -6,6 +6,8 @@
 // Bootstrap.
 @import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/images";
 
 .markdown-rendered {
   // H1 in the description must be visibly smaller than H3 outside.
@@ -19,9 +21,8 @@
     font-size: $h5-font-size * 0.75;
   }
 
-  // equivalent of adding class .img-fluid to element
+  // Make images responsive
   img {
-    max-width: 100%;
-    height: auto;
+    @extend .img-fluid;
   }
 }


### PR DESCRIPTION
Nowy post wiadomości ("aktualności")  jest "parsowany" funkcją "markdownify", a następnie umieszczany w div o Bootstrapowej klasie "my-3". Ten div my-3 jest umieszczany w głównym kontenerze na stronie aktualności.
Sam div my-3 zawiera wyrenderowany markdown nowego posta w którym znajduje się m.in. plaintekst czy obrazki.

W obecnej postaci duże obrazki nie mieszczą się w swoich kontenerach przez co wychodzą poza swój kontener jak widzimy na skrinie:
![image](https://github.com/iiuni/projektzapisy/assets/32998370/a022f26c-7e73-40f5-be75-0a9c62e59646)

Według dokumentacji Bootstrapa v5.0 żeby osiągnąć responsywny image trzeba nadać mu klasę "img-fluid".
https://getbootstrap.com/docs/5.0/content/images/

Według mnie takie rozwiązanie wymagałoby znacznego nakładu kodu, bo musielibyśmy "dostać się" do nowego dodawanego obrazka i nadać mu odpowiednią klasę.
Dlatego moim rozwiązaniem jest dać każdemu dziecku my-3, który jest obrazkiem właściwość max-width:100%. Czyli maksymalna szerokość będzie 100% szerokością rodzica, czyli to co dałaby klasa "img-fluid".

Rozwiązanie przetestowałem na różnych obrazkach, przeglądarkach i urządzeniach.