### PR TITLE
Wymiana biblioteki 'spicery' na 'zod'

### DIFF
--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -13,16 +13,18 @@ import Vue from "vue";
 import Component from "vue-class-component";
 
 // Defines a notification scheme to validate and parse Notifications from JSON.
-const notificationScheme = z.object({
-  id: z.string(),
-  description: z.string(),
-  issued_on: z.string(),
-  target: z.string(),
-}).transform(parsedObject => {
-  parsedObject['issuedOn'] = parsedObject['issued_on'];
-  delete parsedObject['issued_on'];
-  return parsedObject;
-});
+const notificationScheme = z
+  .object({
+    id: z.string(),
+    description: z.string(),
+    issued_on: z.string(),
+    target: z.string(),
+  })
+  .transform((parsedObject) => {
+    parsedObject["issuedOn"] = parsedObject["issued_on"];
+    delete parsedObject["issued_on"];
+    return parsedObject;
+  });
 
 const notificationSchemeArray = z.array(notificationScheme);
 

--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -21,9 +21,12 @@ const notificationScheme = z
     target: z.string(),
   })
   .transform((parsedObject) => {
-    parsedObject["issuedOn"] = parsedObject["issued_on"];
-    delete parsedObject["issued_on"];
-    return parsedObject;
+    return {
+      id: parsedObject.id,
+      description: parsedObject.description,
+      issuedOn: parsedObject.issued_on,
+      target: parsedObject.target,
+    };
   });
 
 const notificationSchemeArray = z.array(notificationScheme);

--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -8,28 +8,21 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
 import "dayjs/locale/pl";
-import { parse, ParseFn, fromMap, aString, anArrayContaining } from "spicery";
+import { z } from "zod";
 import Vue from "vue";
 import Component from "vue-class-component";
 
-class Notification {
-  constructor(
-    public id: string,
-    public description: string,
-    public issuedOn: string,
-    public target: string
-  ) {}
-}
+// Defines a notification scheme to validate and parse Notifications from JSON.
+const notificationScheme = z.object({
+    id: z.string(),
+    description: z.string(),
+    issued_on: z.string(),
+    target: z.string()
+});
 
-// Defines a parser that validates and parses Notifications from JSON.
-const notifications: ParseFn<Notification> = (x: any) =>
-  new Notification(
-    fromMap(x, "id", aString),
-    fromMap(x, "description", aString),
-    fromMap(x, "issued_on", aString),
-    fromMap(x, "target", aString)
-  );
-const notificationsArray = anArrayContaining(notifications);
+const notificationSchemeArray = z.array(notificationScheme);
+
+type Notification = z.infer<typeof notificationScheme>;
 
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
@@ -59,7 +52,7 @@ export default class NotificationsComponent extends Vue {
   getNotifications() {
     return axios
       .get("/notifications/get")
-      .then((r) => parse(notificationsArray)(r.data))
+      .then((r) => notificationSchemeArray.parse(r.data))
       .then((t) => {
         this.n_list = t;
       });
@@ -71,7 +64,7 @@ export default class NotificationsComponent extends Vue {
 
     return axios
       .post("/notifications/delete/all")
-      .then((r) => parse(notificationsArray)(r.data))
+      .then((r) => notificationSchemeArray.parse(r.data))
       .then((t) => {
         this.n_list = t;
       });
@@ -85,7 +78,7 @@ export default class NotificationsComponent extends Vue {
       .post("/notifications/delete", {
         uuid: i,
       })
-      .then((r) => parse(notificationsArray)(r.data))
+      .then((r) => notificationSchemeArray.parse(r.data))
       .then((t) => {
         this.n_list = t;
       });
@@ -124,7 +117,7 @@ export default class NotificationsComponent extends Vue {
             <div class="toast-header">
               <strong class="me-auto"></strong>
               <small class="text-muted mx-2">{{
-                elem.issuedOn | Moment
+                elem.issued_on | Moment
               }}</small>
               <button
                 type="button"

--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -14,10 +14,10 @@ import Component from "vue-class-component";
 
 // Defines a notification scheme to validate and parse Notifications from JSON.
 const notificationScheme = z.object({
-    id: z.string(),
-    description: z.string(),
-    issued_on: z.string(),
-    target: z.string()
+  id: z.string(),
+  description: z.string(),
+  issued_on: z.string(),
+  target: z.string(),
 });
 
 const notificationSchemeArray = z.array(notificationScheme);

--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -18,6 +18,10 @@ const notificationScheme = z.object({
   description: z.string(),
   issued_on: z.string(),
   target: z.string(),
+}).transform(parsedObject => {
+  parsedObject['issuedOn'] = parsedObject['issued_on'];
+  delete parsedObject['issued_on'];
+  return parsedObject;
 });
 
 const notificationSchemeArray = z.array(notificationScheme);
@@ -117,7 +121,7 @@ export default class NotificationsComponent extends Vue {
             <div class="toast-header">
               <strong class="me-auto"></strong>
               <small class="text-muted mx-2">{{
-                elem.issued_on | Moment
+                elem.issuedOn | Moment
               }}</small>
               <button
                 type="button"

--- a/zapisy/package.json
+++ b/zapisy/package.json
@@ -66,7 +66,6 @@
     "prettier": "2.8.8",
     "sass": "1.26.10",
     "sass-loader": "10.5.2",
-    "spicery": "1.1.0",
     "terser-webpack-plugin": "4.2.3",
     "ts-loader": "8.4.0",
     "typescript": "4.0.2",
@@ -76,6 +75,7 @@
     "webpack": "4.47.0",
     "webpack-bundle-analyzer": "3.9.0",
     "webpack-bundle-tracker": "0.4.3",
-    "webpack-cli": "3.3.12"
+    "webpack-cli": "3.3.12",
+    "zod": "3.22.4"
   }
 }

--- a/zapisy/yarn.lock
+++ b/zapisy/yarn.lock
@@ -5344,7 +5344,6 @@ fsevents@~2.1.2:
     prettier: 2.8.8
     sass: 1.26.10
     sass-loader: 10.5.2
-    spicery: 1.1.0
     terser-webpack-plugin: 4.2.3
     ts-loader: 8.4.0
     typescript: 4.0.2
@@ -5358,6 +5357,7 @@ fsevents@~2.1.2:
     webpack-bundle-analyzer: 3.9.0
     webpack-bundle-tracker: 0.4.3
     webpack-cli: 3.3.12
+    zod: 3.22.4
   languageName: unknown
   linkType: soft
 
@@ -8245,13 +8245,6 @@ resolve@^1.14.2:
   languageName: node
   linkType: hard
 
-"spicery@npm:1.1.0":
-  version: 1.1.0
-  resolution: "spicery@npm:1.1.0"
-  checksum: e2b37113a208ded87a52c418f2dd1320ea6ab3e0d7523df5bc25831a17291eb32effbcc42133aa10b2bbfb4a8753d45b8c8e1f9d3eb255c7c0ca0a1508eb1fd0
-  languageName: node
-  linkType: hard
-
 "split-string@npm:^3.0.1, split-string@npm:^3.0.2":
   version: 3.1.0
   resolution: "split-string@npm:3.1.0"
@@ -9431,5 +9424,12 @@ typescript@4.0.2:
     y18n: ^4.0.0
     yargs-parser: ^13.1.2
   checksum: 92c612cd14a9217d7421ae4f42bc7c460472633bfc2e45f7f86cd614a61a845670d3bac7c2228c39df7fcecce0b8c12b2af65c785b1f757de974dcf84b5074f9
+  languageName: node
+  linkType: hard
+
+"zod@npm:3.22.4":
+  version: 3.22.4
+  resolution: "zod@npm:3.22.4"
+  checksum: cb84164addb36b38981135d945e969e2e3ee25aa8d8313361ebc474200893405c7781533300b792eda9a9feaa8a7c06df821cdddf08ee0cf45da258e18f60b83
   languageName: node
   linkType: hard

--- a/zapisy/yarn.lock
+++ b/zapisy/yarn.lock
@@ -5344,6 +5344,7 @@ fsevents@~2.1.2:
     prettier: 2.8.8
     sass: 1.26.10
     sass-loader: 10.5.2
+    tablesorter: 2.31.3
     terser-webpack-plugin: 4.2.3
     ts-loader: 8.4.0
     typescript: 4.0.2
@@ -5752,7 +5753,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"jquery@npm:3.7.1":
+"jquery@npm:3.7.1, jquery@npm:>=1.2.6":
   version: 3.7.1
   resolution: "jquery@npm:3.7.1"
   checksum: 5d2ea78250a8bdfa8e1232b064e11d86b1bc0c7b3e1ebbfee9ed21f1138cff606a07083709fa9d64bbbf94cdba3119b45604a078ba88e9c48fa5ae894eaf8ec6
@@ -8472,6 +8473,15 @@ resolve@^1.14.2:
   version: 1.2.0
   resolution: "symbol-observable@npm:1.2.0"
   checksum: 268834a1d4cba19d40f367e5c2755f612969c8418e43a3be17408e392802a667f8bb542893440d58a080a8ea8da05ea98e27e472b9f4ff6fbda78a21a1a41c53
+  languageName: node
+  linkType: hard
+
+"tablesorter@npm:2.31.3":
+  version: 2.31.3
+  resolution: "tablesorter@npm:2.31.3"
+  dependencies:
+    jquery: ">=1.2.6"
+  checksum: 1c0304f2976973bb8f0edffb1c46e8118dcc4fae966f55c8d7b9407a32b30b92ac8e8a984d4ec6de8af1be05799adf1f904c0bb865acd861cdf575046ee3e0e6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Niniejszy PR jest odpowiedzią na dostrzeżony problem braku bieżącego utrzymania [biblioteki 'spicery'](https://github.com/swissmanu/spicery). Ostatnia aktualizacja jej kodu nastąpiła dwa lata temu, a przy jej tworzeniu brały udział jedynie dwie osoby. Z kolei proponowana przez ten PR [biblioteka 'zod'](https://github.com/colinhacks/zod), która, tak jak 'spicery', pozwala na walidację i parsowanie javascriptowych obiektów, rozwijana jest przez ponad 200 ludzi (w momencie pisania tego opisu jest ich dokładnie okrągłe 256!), a ostatnia wersja została wydana trzy tygodnie temu.

Wybór padł na projekt 'zod', ponieważ znalazłem go jako pierwszego, jednak sami twórcy przekazują na samym końcu opisu informacje o istnieniu innych, podobnych bibliotek (np. Joi, Yup, io-ts). Według autorów 'zoda' mają one pewne ograniczenia względem ich własnego rozwiązania. Zatem w obliczu istnienia tylu alternatyw trudno jest rozstrzygnąć, która biblioteka będzie najlepsza, jednak wydaje się, że biblioteka 'zod' jest po prostu wystarczająca.