### PR TITLE
#1448 - kolumny równej szerokości

### DIFF
--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -248,10 +248,6 @@ colgroup col.table-info-type {
   background-color: #f9f9f9;
 }
 
-th[scope="row"] {
-  width: 50%;
-}
-
 // Required field marker in forms.
 .asteriskField {
   padding-left: 0.25em;

--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -248,6 +248,10 @@ colgroup col.table-info-type {
   background-color: #f9f9f9;
 }
 
+th[scope="row"] {
+  width: 50%;
+}
+
 // Required field marker in forms.
 .asteriskField {
   padding-left: 0.25em;

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -16,13 +16,8 @@
 </div>
 
 <style>
-    #table-info td {
-        width: 100%; 
-        word-wrap: break-word; 
-    }
-
     #table-info th {
-        white-space: nowrap;
+        min-width: max-content; 
     }
 </style>
 

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -15,9 +15,20 @@
     </div>
 </div>
 
+<style>
+    #table-info td {
+        width: 100%; 
+        word-wrap: break-word; 
+    }
+
+    #table-info th {
+        white-space: nowrap;
+    }
+</style>
+
 <table class="table table-bordered table-md-responsive" id="table-info">
     <colgroup>
-        <col class="table-info-type" style="width: 30%"></col>
+        <col class="table-info-type"></col>
     </colgroup>
     <tbody>
         <tr>

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -17,7 +17,7 @@
 
 <table class="table table-bordered table-md-responsive" id="table-info">
     <colgroup>
-        <col class="table-info-type"></col>
+        <col class="table-info-type" style="width: 30%"></col>
     </colgroup>
     <tbody>
         <tr>


### PR DESCRIPTION
dotychczas kolumny tabelek dotyczących poszczególnych przedmiotów miały różne szerokości w przypadku różnych przedmiotów, aktualnie poprawiłem to i teraz każda kolumna zajmuje po 50% przestrzeni