### PR TITLE
#1478 Niedociągnięcie w widoku listy studentów

### DIFF
--- a/zapisy/apps/enrollment/courses/views.py
+++ b/zapisy/apps/enrollment/courses/views.py
@@ -226,6 +226,7 @@ def course_list_view(request, course_slug: str, class_type: int = None):
             'mailto_queue_bcc': mailto(request.user, students_in_queue, bcc=True),
             'class_type': class_type,
     }
+    data.update(prepare_courses_list_data(course.semester))
     return render(request, 'courses/course_parts/course_list.html', data)
 
 


### PR DESCRIPTION
Pull Request dotyczący issue [#1478](https://github.com/iiuni/projektzapisy/issues/1478).  

Na liście studentów brakowało panelu, który pokazuje listę kursów oraz aktualny semestr.  

Problem był spowodowany tym, że w funkcji odpowiedzialnej za przygotowanie odpowiednich danych, które zostaną wyświetlane na stronie (tzn. funkcja `course_list_view`) brakowało uzupełnienia danych dotyczących kursów oraz aktualnego semestru. Brakującą funkcjonalność realizuje funkcja `prepare_courses_list_data` . 
