### PR TITLE
1620 drobne porządki w importach

### DIFF
--- a/zapisy/apps/enrollment/courses/models/group.py
+++ b/zapisy/apps/enrollment/courses/models/group.py
@@ -7,7 +7,9 @@ from django.db import models, transaction
 from django.urls import reverse
 
 from apps.enrollment.courses.models.course_instance import CourseInstance
+from apps.enrollment.courses.models.term import Term
 from apps.notifications.custom_signals import teacher_changed
+from apps.schedulersync.models import TermSyncData
 from apps.users.models import Employee
 
 
@@ -128,8 +130,6 @@ class Group(models.Model):
         This function is operating inside a transaction. If it fails, no changes
         are made to the DB.
         """
-        from apps.enrollment.courses.models.term import Term
-        from apps.schedulersync.models import TermSyncData
 
         def copy_term(t: Term) -> Term:
             classrooms = list(t.classrooms.all())

--- a/zapisy/apps/enrollment/courses/models/term.py
+++ b/zapisy/apps/enrollment/courses/models/term.py
@@ -7,8 +7,6 @@ from django.db.models import signals
 
 from apps.common import days_of_week
 
-from .semester import ChangedDay, Freeday
-
 backup_logger = logging.getLogger('project.backup')
 
 HOURS = [(str(hour), "%s.00" % hour) for hour in range(8, 23)]
@@ -121,6 +119,7 @@ class Term(models.Model):
         :param semester: enrollment.courses.model.Semester
         :param day: DAYS_OF_WEEK or datetime.date
         """
+        from .semester import ChangedDay, Freeday
         query = cls.objects.filter(group__course__semester=semester)
 
         if day is None:

--- a/zapisy/apps/enrollment/courses/models/term.py
+++ b/zapisy/apps/enrollment/courses/models/term.py
@@ -7,6 +7,8 @@ from django.db.models import signals
 
 from apps.common import days_of_week
 
+from .semester import ChangedDay, Freeday
+
 backup_logger = logging.getLogger('project.backup')
 
 HOURS = [(str(hour), "%s.00" % hour) for hour in range(8, 23)]
@@ -119,7 +121,6 @@ class Term(models.Model):
         :param semester: enrollment.courses.model.Semester
         :param day: DAYS_OF_WEEK or datetime.date
         """
-        from .semester import ChangedDay, Freeday
         query = cls.objects.filter(group__course__semester=semester)
 
         if day is None:

--- a/zapisy/apps/enrollment/records/apps.py
+++ b/zapisy/apps/enrollment/records/apps.py
@@ -10,5 +10,5 @@ class RecordsAppConfig(AppConfig):
     name = 'apps.enrollment.records'
 
     def ready(self):
-        import apps.enrollment.records.signals  # noqa
-        import apps.enrollment.records.tasks  # noqa
+        import apps.enrollment.records.signals  # noqa: F401
+        import apps.enrollment.records.tasks  # noqa: F401

--- a/zapisy/apps/grade/poll/apps.py
+++ b/zapisy/apps/grade/poll/apps.py
@@ -6,4 +6,4 @@ class PollAppConfig(AppConfig):
     verbose_name = "Ocena zajęć"
 
     def ready(self):
-        import apps.grade.poll.signals  # noqa
+        import apps.grade.poll.signals  # noqa: F401

--- a/zapisy/apps/grade/ticket_create/apps.py
+++ b/zapisy/apps/grade/ticket_create/apps.py
@@ -6,4 +6,4 @@ class TicketsAppConfig(AppConfig):
     verbose_name = "Tickets"
 
     def ready(self):
-        import apps.grade.ticket_create.signals  # noqa
+        import apps.grade.ticket_create.signals  # noqa: F401

--- a/zapisy/apps/notifications/apps.py
+++ b/zapisy/apps/notifications/apps.py
@@ -5,4 +5,4 @@ class NotificationsConfig(AppConfig):
     name = "apps.notifications"
 
     def ready(self):
-        import apps.notifications.signals  # noqa
+        import apps.notifications.signals  # noqa: F401

--- a/zapisy/apps/schedule/models/event.py
+++ b/zapisy/apps/schedule/models/event.py
@@ -11,8 +11,6 @@ from apps.enrollment.courses.models.course_instance import CourseInstance
 from apps.enrollment.courses.models.group import Group
 from apps.enrollment.records.models import Record, RecordStatus
 
-from .term import Term
-
 
 class Event(models.Model):
     TYPE_EXAM = '0'
@@ -116,6 +114,7 @@ class Event(models.Model):
 
                 # if status changes to accepted, validate all term objects
                 if self.status == Event.STATUS_ACCEPTED:
+                    from .term import Term
                     for term in Term.objects.filter(event=self):
                         term.clean()
 
@@ -123,6 +122,7 @@ class Event(models.Model):
 
     def remove(self):
         """Removing all terms bounded with given event."""
+        from .term import Term
         terms = Term.objects.filter(event=self)
         for term in terms:
             term.delete()

--- a/zapisy/apps/schedule/models/event.py
+++ b/zapisy/apps/schedule/models/event.py
@@ -5,11 +5,13 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import ValidationError
 from django.db import models
 from django.http import Http404
+from django.urls import reverse
 
 from apps.enrollment.courses.models.course_instance import CourseInstance
 from apps.enrollment.courses.models.group import Group
 from apps.enrollment.records.models import Record, RecordStatus
 
+from .term import Term
 
 class Event(models.Model):
     TYPE_EXAM = '0'
@@ -58,7 +60,6 @@ class Event(models.Model):
     edited = models.DateTimeField(auto_now=True)
 
     def get_absolute_url(self):
-        from django.urls import reverse
 
         if self.group:
             return reverse('group-view', args=[str(self.group_id)])
@@ -114,7 +115,6 @@ class Event(models.Model):
 
                 # if status changes to accepted, validate all term objects
                 if self.status == Event.STATUS_ACCEPTED:
-                    from .term import Term
                     for term in Term.objects.filter(event=self):
                         term.clean()
 
@@ -122,7 +122,6 @@ class Event(models.Model):
 
     def remove(self):
         """Removing all terms bounded with given event."""
-        from .term import Term
         terms = Term.objects.filter(event=self)
         for term in terms:
             term.delete()

--- a/zapisy/apps/schedule/models/event.py
+++ b/zapisy/apps/schedule/models/event.py
@@ -13,6 +13,7 @@ from apps.enrollment.records.models import Record, RecordStatus
 
 from .term import Term
 
+
 class Event(models.Model):
     TYPE_EXAM = '0'
     TYPE_TEST = '1'

--- a/zapisy/apps/schedule/models/specialreservation.py
+++ b/zapisy/apps/schedule/models/specialreservation.py
@@ -9,8 +9,8 @@ from apps.enrollment.courses.models.semester import Semester
 from apps.enrollment.courses.models.term import Term as CourseTerm
 from apps.schedule.models.event import Event
 
-from .event import Event
 from .term import Term
+
 
 class SpecialReservationQuerySet(models.query.QuerySet):
     def on_day_of_week(self, day_of_week):

--- a/zapisy/apps/schedule/models/specialreservation.py
+++ b/zapisy/apps/schedule/models/specialreservation.py
@@ -10,6 +10,7 @@ from apps.enrollment.courses.models.term import Term as CourseTerm
 from apps.schedule.models.event import Event
 
 from .term import Term
+from .event import Event
 
 
 class SpecialReservationQuerySet(models.query.QuerySet):

--- a/zapisy/apps/schedule/models/specialreservation.py
+++ b/zapisy/apps/schedule/models/specialreservation.py
@@ -7,7 +7,6 @@ from apps.common import days_of_week
 from apps.enrollment.courses.models.classroom import Classroom
 from apps.enrollment.courses.models.semester import Semester
 from apps.enrollment.courses.models.term import Term as CourseTerm
-from apps.schedule.models.event import Event
 
 from .term import Term
 from .event import Event

--- a/zapisy/apps/schedule/models/specialreservation.py
+++ b/zapisy/apps/schedule/models/specialreservation.py
@@ -9,6 +9,8 @@ from apps.enrollment.courses.models.semester import Semester
 from apps.enrollment.courses.models.term import Term as CourseTerm
 from apps.schedule.models.event import Event
 
+from .event import Event
+from .term import Term
 
 class SpecialReservationQuerySet(models.query.QuerySet):
     def on_day_of_week(self, day_of_week):
@@ -110,7 +112,6 @@ class SpecialReservation(models.Model):
                                                          start_time=self.start_time,
                                                          end_time=self.end_time)
 
-        from .term import Term
         candidate_days = self.semester.get_all_days_of_week(
             self.dayOfWeek, start_date=max(
                 datetime.now().date(), self.semester.lectures_beginning))
@@ -171,8 +172,6 @@ class SpecialReservation(models.Model):
         verbose_name_plural = 'rezerwacje stałe'
 
     def create_event(self, author_id):
-        from .term import Term
-        from .event import Event
 
         Event.objects.filter(reservation=self).delete()
 

--- a/zapisy/apps/schedule/views.py
+++ b/zapisy/apps/schedule/views.py
@@ -22,6 +22,7 @@ from apps.schedule.forms import (ConflictsForm, DecisionForm, EventForm, EventMe
                                  EventModerationMessageForm, EditTermFormSet, NewTermFormSet,
                                  ExtraTermsNumber)
 from apps.schedule.models.event import Event
+from apps.schedule.models.message import EventModerationMessage, EventMessage
 from apps.schedule.models.specialreservation import SpecialReservation
 from apps.schedule.models.term import Term
 from apps.schedule.utils import EventAdapter, get_week_range_by_date
@@ -111,7 +112,6 @@ def edit_reservation(request, event_id=None):
 
 
 def session(request, semester=None):
-    from apps.enrollment.courses.models.semester import Semester
 
     exams_filter = ExamFilter(request.GET, queryset=Term.get_exams())
 
@@ -199,7 +199,6 @@ def events(request):
 
 
 def event(request, event_id):
-    from apps.schedule.models.message import EventModerationMessage, EventMessage
 
     event = Event.get_event_or_404(event_id, request.user)
     moderation_messages = EventModerationMessage.get_event_messages(event)

--- a/zapisy/apps/schedule/views.py
+++ b/zapisy/apps/schedule/views.py
@@ -18,18 +18,15 @@ from apps.enrollment.courses.models.classroom import Classroom
 from apps.enrollment.courses.models.semester import Semester
 from apps.enrollment.courses.models.term import Term as CourseTerm
 from apps.schedule.filters import EventFilter, ExamFilter
-from apps.schedule.forms import (ConflictsForm, DecisionForm, EventForm, EventMessageForm,
-                                 EventModerationMessageForm, EditTermFormSet, NewTermFormSet,
+from apps.schedule.forms import (ConflictsForm, DecisionForm, DoorChartForm, EventForm, EventMessageForm,
+                                 EventModerationMessageForm, TableReportForm, EditTermFormSet, NewTermFormSet,
                                  ExtraTermsNumber)
+from apps.schedule.fullcalendar import FullCalendarView
 from apps.schedule.models.event import Event
 from apps.schedule.models.message import EventModerationMessage, EventMessage
 from apps.schedule.models.specialreservation import SpecialReservation
 from apps.schedule.models.term import Term
 from apps.schedule.utils import EventAdapter, get_week_range_by_date
-
-from .forms import DoorChartForm, TableReportForm
-from .fullcalendar import FullCalendarView
-from .models.message import EventModerationMessage
 
 
 @login_required

--- a/zapisy/apps/theses/apps.py
+++ b/zapisy/apps/theses/apps.py
@@ -6,4 +6,4 @@ class ThesesConfig(AppConfig):
     verbose_name = 'Theses'
 
     def ready(self):
-        from . import signals  # noqa
+        from . import signals  # noqa: F401

--- a/zapisy/apps/users/apps.py
+++ b/zapisy/apps/users/apps.py
@@ -30,4 +30,4 @@ class UsersConfig(AppConfig):
         setattr(auth_models.AnonymousUser, 'student', None)
         setattr(auth_models.AnonymousUser, 'employee', None)
 
-        import apps.users.signals  # noqa
+        import apps.users.signals  # noqa: F401

--- a/zapisy/apps/users/apps.py
+++ b/zapisy/apps/users/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig
 from django.contrib.auth import get_user_model
+from django.contrib.auth import models as auth_models
 
 
 class UsersConfig(AppConfig):
@@ -26,7 +27,6 @@ class UsersConfig(AppConfig):
         setattr(UserModel, 'student', property(get_student))
         setattr(UserModel, 'employee', property(get_employee))
 
-        from django.contrib.auth import models as auth_models
         setattr(auth_models.AnonymousUser, 'student', None)
         setattr(auth_models.AnonymousUser, 'employee', None)
 

--- a/zapisy/apps/users/apps.py
+++ b/zapisy/apps/users/apps.py
@@ -1,6 +1,5 @@
 from django.apps import AppConfig
 from django.contrib.auth import get_user_model
-from django.contrib.auth import models as auth_models
 
 
 class UsersConfig(AppConfig):
@@ -27,6 +26,7 @@ class UsersConfig(AppConfig):
         setattr(UserModel, 'student', property(get_student))
         setattr(UserModel, 'employee', property(get_employee))
 
+        from django.contrib.auth import models as auth_models
         setattr(auth_models.AnonymousUser, 'student', None)
         setattr(auth_models.AnonymousUser, 'employee', None)
 


### PR DESCRIPTION
Przejrzałam wszystkie pliki pod kątem innych importów zlokalizowanych niezgodnie regułami przy użyciu poleceń `grep -r -A 10000 '^.*class ' | grep '.*import '`, `grep -r -A 10000 '^.*def ' | grep '.*import '`, `grep 'import ' $(grep -rL 'class')` oraz `grep 'import ' $(grep -rL 'def ')` (uznając słowa kluczowe `class` i `def` za pewną granicę między importami z początku pliku a jego resztą) i nie wykazały one żadnych anomalii poza tymi wymienionymi w issue #1620. W plikach tych przeniosłam wszystkie importy na początek tychże plików, ponieważ nie znalazłam żadnego uzasadnienia, żeby musiały tam pozostać. Wyjątkiem są importy z plików
```
enrollment/courses/models/term.py
users/apps.py
schedule/models/event.py
```
w których przeniesienie importu psuje działanie systemu (czy i jak można coś z tym zrobić to pewnie kwestia na osobne issue).

Co do importów zakończonych komentarzem `# noqa` - wyszukałam wszystkie miejsca, w których występują i tam, gdzie nie było to dospecyfikowane, ograniczyłam ich działanie do reguły F401 (imported but unused), jako że jest to jedyna reguła, którą te linie łamią.