### PR TITLE
1626  Niezaznaczalne treści w liście tematów prac dyplomowych 

### DIFF
--- a/zapisy/apps/theses/assets/components/ThesesList.vue
+++ b/zapisy/apps/theses/assets/components/ThesesList.vue
@@ -60,17 +60,8 @@ export default class ThesesList extends Vue {
 }
 </script>
 
-<style scoped>
-.selection-none {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-</style>
-
 <template>
-  <table class="table table-hover selection-none table-responsive-md">
+  <table class="table table-hover table-responsive-md">
     <thead id="table-header">
       <tr class="text-center">
         <th>


### PR DESCRIPTION
Przyczyną niezaznaczalności treści w liście tamatów prac dypkomowych jest dodana do tabeli klasa "selection-none", która jak nazwa wskazuje blokuje możliwość zaznaczania tekstów w tabeli za pomocą ustawienia na **none** atrybutów m.in. **user-select** oraz innych, podobnych do niej modulo używana przeglądarka, co przedstawiają poniższe skriny.
![image](https://github.com/iiuni/projektzapisy/assets/32998370/6b944461-6dce-43c7-aac6-7c9201343074)
![image](https://github.com/iiuni/projektzapisy/assets/32998370/11969324-a743-406d-a029-63d55a4ac1dc)

Widzimy, że komuś faktycznie zależało na tym żeby tekst w tabeli był niezaznaczalny.

Jako że sam nie domyśliłem się jaki jest tego powód postanowiłem prześledzić historie powstania tych linijek kodu. W celu poznania myśli autora użyłem mojego ulubionego polecenia, którego wynik widzimy poniżej.
![image](https://github.com/iiuni/projektzapisy/assets/32998370/6c82a8a1-a45d-4fb7-b369-947a7d5489a0)

Autorem commita **ab3f76ed0** był **barnij**.

Moja mniej już ulubiona komenda git show pokazuje, że jest to część bardzo dużego commita wprowadzającego całą nową podstronę obsługi prac dyplomowych.
![image](https://github.com/iiuni/projektzapisy/assets/32998370/1aabdb78-35e4-4237-9801-e7f209726e70)

W PR odpowiadającym za tą zmianę "Nowy system obsługi prac dyplomowych #818" znalazłem tę zmianę w commicie _1b6923f1e687e4169b79a2066889a1f1abbab86f_  o komentarzu _"Theses list is now a table"_.

Reasumując - z tych poszukiwań nic nie wynikło i niczego się nie dowiedziałem, więc po prostu usunąłem tę klasę w pliku **ThesesList.vue** i przetestowałem stronę po tych zmianach. Podstrona prace dyplomowe dalej działa bez zarzutów a ponadto można zaznaczyć tabelę jak widać na skrinie poniżej.
![image](https://github.com/iiuni/projektzapisy/assets/32998370/5da2a612-35de-487b-9e0e-46baec70d68f)

 