### PR TITLE
#1642 - Removing notifications doesn't hide the widget anymore

### DIFF
--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -109,6 +109,7 @@ export default class NotificationsComponent extends Vue {
         id="navbarDropdown"
         role="button"
         data-bs-toggle="dropdown"
+        data-bs-auto-close="outside"
         aria-haspopup="true"
         aria-expanded="false"
       >


### PR DESCRIPTION
Add data-bs-auto-close="outside" to notifications dropdown to prevent it from closing when clicking anywhere inside it.
Default behaviour for bootstrap 4/5 by default hides the dropdown whenever you click outside of it or on a dropdown-item element ("All events bubble up with relatedTarget property, whose value is the toggling anchor element" resulting in hiding the widget).
Dropdown-item is not used in this widget therefore before the migration it had only been hidden when the click occurred outside of the widget.
In bootstrap 5 "All dropdown events are fired at the toggling element and then bubbled up" without the relatedTarget property 
instead handling all clicks inside according to the data-bs-auto-close specified behavior.