### PR TITLE
#1653 - Poprawki DOM w szablonie przedmiotu

### DIFF
--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -17,7 +17,13 @@
 
 <table class="table table-bordered table-md-responsive table-infobox">
     <style>
+        #hours ul, .badges ul {
+            padding: 0;
+            margin: 0;
+        }
+
         #hours ul li {
+            list-style-type: none;
             float: left;
         }
             
@@ -75,7 +81,7 @@
         {% if course.tags.all %}
         <tr>
             <th scope="row">Tagi</th>
-            <td>
+            <td class="badges">
                 <ul>
                     {% for tag in course.tags.all %}    
                         <li class="badge bg-success me-2">{{ tag }}</li>
@@ -87,7 +93,7 @@
         {% if course.effects.all %}
         <tr>
             <th>Grupy efektów kształcenia</th>
-            <td>
+            <td class="badges">
                 <ul>
                     {% for effect in course.effects.all %}
                         <li class="badge bg-info me-2">{{ effect }}</li>

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -55,7 +55,6 @@
                 </ul>
                 {% endspaceless %}
             </td>
-            
         </tr>
         <tr>
             <th scope="row">Rodzaj</th>
@@ -93,7 +92,7 @@
             <td>
                 <ul>
                     {% for effect in course.effects.all %}
-                        <il class="badge bg-info me-2">{{ effect }}</il>
+                        <li class="badge bg-info me-2">{{ effect }}</li>
                     {% endfor %}
                 </ul>
             </td>
@@ -101,7 +100,6 @@
         {% endif %}
     </tbody>
 </table>
-
 <div class="description">
     <h2>Opis przedmiotu:</h2>
     {% markdown course.description|default:"Brak" %}

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -35,18 +35,27 @@
             <th scope="row">Liczba godzin</th>
             <td id="hours">
                 <style>
-                    #hours span + span::before {
+                    #hours ul li {
+                        display: inline-block;
+                    }
+            
+                    #hours ul li + li::before {
                         content: '+';
                         margin: 0 .5em;
                     }
                 </style>
-                {% if course.hours_lecture %}<span>{{ course.hours_lecture }} (wyk.)</span>{% endif %}
-                {% if course.hours_exercise %}<span>{{ course.hours_exercise }} (ćw.)</span>{% endif %}
-                {% if course.hours_lab %}<span>{{ course.hours_lab }} (prac.)</span>{% endif %}
-                {% if course.hours_exercise_lab %}<span>{{ course.hours_exercise_lab }} (ćw-prac.)</span>{% endif %}
-                {% if course.hours_seminar %}<span>{{ course.hours_seminar }} (sem.)</span>{% endif %}
-                {% if course.hours_recap %}<span>{{ course.hours_recap }} (rep.)</span>{% endif %}
+                {% spaceless %}
+                <ul>
+                    {% if course.hours_lecture %}<li>{{ course.hours_lecture }} (wyk.)</li>{% endif %}
+                    {% if course.hours_exercise %}<li>{{ course.hours_exercise }} (ćw.)</li>{% endif %}
+                    {% if course.hours_lab %}<li>{{ course.hours_lab }} (prac.)</li>{% endif %}
+                    {% if course.hours_exercise_lab %}<li>{{ course.hours_exercise_lab }} (ćw-prac.)</li>{% endif %}
+                    {% if course.hours_seminar %}<li>{{ course.hours_seminar }} (sem.)</li>{% endif %}
+                    {% if course.hours_recap %}<li>{{ course.hours_recap }} (rep.)</li>{% endif %}
+                </ul>
+                {% endspaceless %}
             </td>
+            
         </tr>
         <tr>
             <th scope="row">Rodzaj</th>
@@ -70,9 +79,11 @@
         <tr>
             <th scope="row">Tagi</th>
             <td>
-                {% for tag in course.tags.all %}
-                    <span class="badge bg-success me-2">{{ tag }}</span>
-                {% endfor %}
+                <ul>
+                    {% for tag in course.tags.all %}    
+                        <li class="badge bg-success me-2">{{ tag }}</li>
+                    {% endfor %}
+                </ul>
             </td>
         </tr>
         {% endif %}
@@ -80,9 +91,11 @@
         <tr>
             <th>Grupy efektów kształcenia</th>
             <td>
-                {% for effect in course.effects.all %}
-                    <span class="badge bg-info me-2">{{ effect }}</span>
-                {% endfor %}
+                <ul>
+                    {% for effect in course.effects.all %}
+                        <il class="badge bg-info me-2">{{ effect }}</il>
+                    {% endfor %}
+                </ul>
             </td>
         </tr>
         {% endif %}

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -100,6 +100,7 @@
         {% endif %}
     </tbody>
 </table>
+
 <div class="description">
     <h2>Opis przedmiotu:</h2>
     {% markdown course.description|default:"Brak" %}

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -17,11 +17,8 @@
 
 <table class="table table-bordered table-md-responsive table-infobox">
     <style>
-        #hours ul {
-            display: flex;
-            padding: 0;
-            margin: 0;
-            list-style-type: none;
+        #hours ul li {
+            float: left;
         }
             
         #hours ul li + li::before {

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -16,6 +16,19 @@
 </div>
 
 <table class="table table-bordered table-md-responsive table-infobox">
+    <style>
+        #hours ul {
+            display: flex;
+            padding: 0;
+            margin: 0;
+            list-style-type: none;
+        }
+            
+        #hours ul li + li::before {
+            content: '+';
+            margin: 0 .5em;
+        }
+    </style>
     <colgroup>
         <col class="header-column"></col>
     </colgroup>
@@ -34,17 +47,6 @@
         <tr>
             <th scope="row">Liczba godzin</th>
             <td id="hours">
-                <style>
-                    #hours ul li {
-                        display: inline-block;
-                    }
-            
-                    #hours ul li + li::before {
-                        content: '+';
-                        margin: 0 .5em;
-                    }
-                </style>
-                {% spaceless %}
                 <ul>
                     {% if course.hours_lecture %}<li>{{ course.hours_lecture }} (wyk.)</li>{% endif %}
                     {% if course.hours_exercise %}<li>{{ course.hours_exercise }} (ćw.)</li>{% endif %}
@@ -53,7 +55,6 @@
                     {% if course.hours_seminar %}<li>{{ course.hours_seminar }} (sem.)</li>{% endif %}
                     {% if course.hours_recap %}<li>{{ course.hours_recap }} (rep.)</li>{% endif %}
                 </ul>
-                {% endspaceless %}
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
Przyczyną występowania dodatkowego odstępu przed plusami w rzędzie "Liczba godzin" jest sama specyfika HTMLa - kiedy używamy `display: inline` (domyślna wartość dla m.in. `<span>`ów), to przeglądarka kondensuje wszystkie spacje (w tym newline'y występujące między elementami w kodzie) w jedną spację. 
Po rozpatrzeniu kilku możliwych rozwiązań najlepszym z nich jakie udało mi się wymyślić jest dodanie Djangowego tagu `{% spaceless %}`okalającego problematyczne elementy. Dzięki temu odstępy znikają, a kod nadal jest czytelny.
![obraz](https://github.com/iiuni/projektzapisy/assets/96109338/8c07a14d-3d8a-4a6f-9307-bda34142243d)

Dodatkowo zgodnie z sugestią we wszystkich rzędach gdzie były używane `<span>`y zostały one zastąpione listami wypunktowanymi z elementami. Został przy tym zachowany efekt wizualny.
![obraz](https://github.com/iiuni/projektzapisy/assets/96109338/5ab504c0-dadd-4832-aced-36675b11a745)

closes #1653 