### PR TITLE
Naprawienie niepoprawnie wyświetlającej się liczby zapisanych osób

### DIFF
--- a/zapisy/apps/enrollment/courses/templates/courses/group.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/group.html
@@ -58,8 +58,8 @@
         <h3>Lista osób zapisanych na przedmiot:</h3>
         <p>
             Liczba zapisanych osób: {{students_in_group|length}} / {{group.limit}}
-            {% for gs in guaranteed_spots %}
-                + 
+            {% for gs in group.guaranteed_spots.all %}
+                +
                 <span title="Miejsca gwarantowane dla grupy {{gs.role.name}}.">
                     {{ gs.limit }}
                     <span class="badge bg-dark">{{ gs.role.name }}</span>


### PR DESCRIPTION
Przed poprawką:
![image](https://github.com/iiuni/projektzapisy/assets/95649808/88077b44-5d31-4e30-b15b-b9039cadb08d)

Po poprawce:
![image](https://github.com/iiuni/projektzapisy/assets/95649808/9e91db61-60f4-43f1-94de-a1bc1f75b4e8)

Pytanie, czy chcemy rozbijać limit na sumę (uwzględniając poszczególne role, jak np. ISIM) czy raczej przedstawić limit jako jedną liczbę (tj. zamiast 14+7, dać 21).