### PR TITLE
1586 szybsze i wygodniejsze wybieranie studentow do tematu pracy dyplomowej

### DIFF
--- a/zapisy/apps/theses/templates/theses/thesis_form.html
+++ b/zapisy/apps/theses/templates/theses/thesis_form.html
@@ -55,7 +55,6 @@
 
 <script>
     $(document).ready(function() {
-        let timer;
         let previousInput;
         let selectedStudentIds = [];
 
@@ -81,30 +80,36 @@
 
             $.ajax({
                 url: '{% url "theses:get_data" %}',
-                type: 'POST',
+                type: 'GET',
                 data: {
                     'input_value': inputValue,
                     'csrfmiddlewaretoken': '{{ csrf_token }}'
                 },
                 success: function (data) {
-                    $('#id_students').html(data.filtered_students);
-                    updateSelectedStudents();
+                    $('#id_all_students').html(data.filtered_students);
                 },
                 error: function(xhr, status, error) {
                     console.error("Something went wrong :(");
                 }
             });
         }
-    
+
         function updateSelectedStudents() {
-            $('#id_students option:selected').each(function() {
+            const all_students = $('#id_all_students');
+            const picked_students = $('#id_students');
+
+            picked_students.find('option:selected').each(function() {
+                all_students.append($(this).clone().prop('selected', false));
                 const student_id = $(this).val();
                 const index = selectedStudentIds.indexOf(student_id);
-                if (index == -1) {
-                    selectedStudentIds.push(student_id);
-                } else {
-                    selectedStudentIds.splice(index, 1);
-                }
+                selectedStudentIds.splice(index, 1);
+                $(this).remove();
+            });
+
+            all_students.find('option:selected').each(function() {
+                picked_students.append($(this).clone().prop('selected', false));
+                selectedStudentIds.push($(this).val());
+                $(this).remove();
             });
             $('#id_selected_students').val(selectedStudentIds.join(','));
             console.log('Selected Student IDs:', selectedStudentIds);
@@ -113,7 +118,7 @@
 
         const debouncedInputHandler = debounce(handleInput, 200);
         $("#id_user_input").on("input", debouncedInputHandler);
-        $('#id_students').on('change', updateSelectedStudents);
+        $('#id_all_students, #id_students').on('change', updateSelectedStudents);
     });
 </script>
 

--- a/zapisy/apps/theses/templates/theses/thesis_form.html
+++ b/zapisy/apps/theses/templates/theses/thesis_form.html
@@ -43,6 +43,7 @@
     {% endif %}
 
     <form method="POST" id="confirm-submit" class="post-form">
+        <input type="hidden" id="id_selected_students" name="selected_students" value="">
         {% csrf_token %}
         {% crispy thesis_form %}
     </form>
@@ -51,4 +52,69 @@
         {% render_bundle 'theses-theses-change' %} 
     {% endif %}
 </div>
+
+<script>
+    $(document).ready(function() {
+        let timer;
+        let previousInput;
+        let selectedStudentIds = [];
+
+        function debounce(func, delay) {
+            let timer;
+            return function() {
+                const context = this;
+                const args = arguments;
+                clearTimeout(timer);
+                timer = setTimeout(function() {
+                    func.apply(context, args);
+                }, delay);
+            };
+        }
+
+        function handleInput() {
+            const inputValue = $("#id_user_input").val().trim();
+
+            if (inputValue === previousInput || inputValue === '') {
+                return;
+            }
+            previousInput = inputValue;
+
+            $.ajax({
+                url: '{% url "theses:get_data" %}',
+                type: 'POST',
+                data: {
+                    'input_value': inputValue,
+                    'csrfmiddlewaretoken': '{{ csrf_token }}'
+                },
+                success: function (data) {
+                    $('#id_students').html(data.filtered_students);
+                    updateSelectedStudents();
+                },
+                error: function(xhr, status, error) {
+                    console.error("Something went wrong :(");
+                }
+            });
+        }
+    
+        function updateSelectedStudents() {
+            $('#id_students option:selected').each(function() {
+                const student_id = $(this).val();
+                const index = selectedStudentIds.indexOf(student_id);
+                if (index == -1) {
+                    selectedStudentIds.push(student_id);
+                } else {
+                    selectedStudentIds.splice(index, 1);
+                }
+            });
+            $('#id_selected_students').val(selectedStudentIds.join(','));
+            console.log('Selected Student IDs:', selectedStudentIds);
+            console.log('Hidden input value:', $('#id_selected_students').val());
+        }
+
+        const debouncedInputHandler = debounce(handleInput, 200);
+        $("#id_user_input").on("input", debouncedInputHandler);
+        $('#id_students').on('change', updateSelectedStudents);
+    });
+</script>
+
 {% endblock %}

--- a/zapisy/apps/theses/urls.py
+++ b/zapisy/apps/theses/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path('<int:id>/form/<int:studentid>', views.gen_form, name="gen_form"),
     path('<int:id>/rejecter', views.rejecter_decision, name="rejecter_thesis"),
     path('<int:id>/delete', views.delete_thesis, name="delete_thesis"),
+    path('ajax/get_data/', views.get_data, name='get_data'),
 ]

--- a/zapisy/apps/theses/views.py
+++ b/zapisy/apps/theses/views.py
@@ -213,6 +213,24 @@ def edit_thesis(request, id):
         'old_instance': thesis_dict
     })
 
+from django.http import JsonResponse
+from django.db.models import Q
+
+def get_data(request):
+    if request.method == 'POST' and request.is_ajax():
+        input_value = request.POST.get('input_value', '')
+        
+        filtered = Student.objects.filter(
+            Q(matricula__icontains=input_value) |
+            Q(user__first_name__icontains=input_value) |
+            Q(user__last_name__icontains=input_value)
+        )
+        
+        students_html = ""
+        for student in filtered:
+            students_html += f"<option value='{student.pk}'>{student.user.get_full_name()} ({student.matricula})</option>"
+        
+        return JsonResponse({'filtered_students': students_html})
 
 @employee_required
 def new_thesis(request):

--- a/zapisy/apps/theses/views.py
+++ b/zapisy/apps/theses/views.py
@@ -217,15 +217,14 @@ from django.http import JsonResponse
 from django.db.models import Q
 
 def get_data(request):
-    if request.method == 'POST' and request.is_ajax():
-        input_value = request.POST.get('input_value', '')
-        
+    if request.method == 'GET':
+        input_value = request.GET.get('input_value', '')
+
         filtered = Student.objects.filter(
             Q(matricula__icontains=input_value) |
             Q(user__first_name__icontains=input_value) |
             Q(user__last_name__icontains=input_value)
         )
-        
         students_html = ""
         for student in filtered:
             students_html += f"<option value='{student.pk}'>{student.user.get_full_name()} ({student.matricula})</option>"


### PR DESCRIPTION
**!UWAGA! To nie jest finalna wersja rozwiązania issue #1586.** 

### Co nie działa lub co może działać lepiej?
- **filtrowanie studentów:** stare zapytanie do serwera lubi pospuć odfiltrowanych studentów
- **edycja pracy dyplomowej:** nie wczytuje studentów

### Wprowadzone zmiany wizualne

Początkowa lista studentów jest pusta i jest dynamicznie ładowana.
Okno z studentami zostało podzielone, tak by z lewej strony byli studenci pasujący do wprowadzonego tekstu w polu `Znajdź studenta`, a z prawej już wybrani studenci.
![wyglad](https://github.com/iiuni/projektzapisy/assets/73169869/fedd55c0-ce7c-445c-a763-dfbc64b8fa85)

Wybranie studenta z pola `Studenci` przenosi go do pola `Wybrani studenci`. Analogicznie w drugą stronę.
![studenci](https://github.com/iiuni/projektzapisy/assets/73169869/eaa0adcc-3758-4b22-b86d-9cc595dbaa17)

### Wprowadzone zmiany w kodzie

Za wyświetlenie przefiltrowanych studentów odpowiada skrypt w `thesis_form.html`, a za samą filtracje `get_data(request)` z `views.py`.

Wybranych przez użytkownika studentów trzymaym dodatkowo w niewidocznym polu `selected_students` na potrzeby późniejszej walidacji formularza.
Dlaczego?
Konieczne było ustawienie `queryset` dla pola `students`, `self.data['students']` i `self.cleaned_data['students]` na wybranych studentów.




