### PR TITLE
1701 promotor pomocniczy nie powinien głosować na swój temat pracy dyplomowej

### DIFF
--- a/zapisy/apps/theses/admin.py
+++ b/zapisy/apps/theses/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from apps.theses.forms import RemarkFormAdmin, ThesisFormAdmin, VoteFormAdmin
+from apps.theses.forms import RemarkFormAdmin, ThesisFormAdmin
 from apps.theses.models import Remark, ThesesSystemSettings, Thesis, Vote
 
 
@@ -21,8 +21,8 @@ class RemarkAdmin(admin.ModelAdmin):
 
 
 class VoteAdmin(admin.ModelAdmin):
-    autocomplete_fields = []
-    form = VoteFormAdmin
+    def has_add_permission(self, request):
+        return False
 
 
 class ThesesSystemSettingsAdmin(admin.ModelAdmin):

--- a/zapisy/apps/theses/forms.py
+++ b/zapisy/apps/theses/forms.py
@@ -22,12 +22,6 @@ class RemarkFormAdmin(forms.ModelForm):
         fields = '__all__'
 
 
-class VoteFormAdmin(forms.ModelForm):
-    class Meta:
-        model = Vote
-        fields = '__all__'
-
-
 class ThesisFormBase(forms.ModelForm):
     class Meta:
         model = Thesis

--- a/zapisy/apps/theses/users.py
+++ b/zapisy/apps/theses/users.py
@@ -6,16 +6,23 @@ from apps.users.models import Employee, is_employee, is_user_in_group
 THESIS_BOARD_GROUP_NAME = "Komisja prac dyplomowych"
 
 
-def get_theses_board():
+def get_board():
     """Returns all members of the theses board."""
     return Employee.objects.select_related(
         'user'
     ).filter(user__groups__name=THESIS_BOARD_GROUP_NAME)
 
 
+def get_thesis_board(thesis):
+    """Returns all members of the board for specific thesis."""
+    if thesis.supporting_advisor is None:
+        return get_board().exclude(id__in=[thesis.advisor.id])
+    return get_board().exclude(id__in=[thesis.advisor.id, thesis.supporting_advisor.id])
+
+
 def get_num_board_members() -> int:
     """Returns the number of theses board members."""
-    return get_theses_board().count()
+    return get_board().count()
 
 
 def is_theses_board_member(user: User) -> bool:

--- a/zapisy/apps/theses/views.py
+++ b/zapisy/apps/theses/views.py
@@ -10,7 +10,7 @@ from django.forms.models import model_to_dict
 from apps.theses.enums import ThesisStatus, ThesisVote
 from apps.theses.forms import EditThesisForm, RejecterForm, RemarkForm, ThesisForm, VoteForm
 from apps.theses.models import Thesis
-from apps.theses.users import get_theses_board, is_master_rejecter, is_theses_board_member
+from apps.theses.users import get_thesis_board, is_master_rejecter, is_theses_board_member
 from apps.users.decorators import employee_required
 from apps.users.models import Student
 
@@ -69,7 +69,8 @@ def view_thesis(request, id):
         raise PermissionDenied
     can_edit_thesis = thesis.is_mine(request.user)
     save_and_verify = thesis.is_mine(request.user) and thesis.is_returned
-    can_vote = thesis.is_voting_active and board_member
+    is_advisor = thesis.is_among_advisors(request.user)
+    can_vote = thesis.is_voting_active and board_member and not is_advisor
     show_master_rejecter = is_master_rejecter(request.user) and (
         thesis.is_voting_active or thesis.is_returned)
     can_download_declarations = thesis.is_student_assigned(
@@ -77,7 +78,7 @@ def view_thesis(request, id):
 
     students = thesis.students.all()
 
-    all_voters = get_theses_board()
+    all_voters = get_thesis_board(thesis)
     votes = []
     voters = []
     for vote in thesis.thesis_votes.all():


### PR DESCRIPTION
Przed wprowadzeniem zmian promotorzy (zarówno główni jak i pomocniczy) będący w komisji ds. prac dyplomowych mogli głosować na temat pracy zgłoszony przez siebie. Dodatkowo przychodziły powiadomienia o możliwości głosowania oraz widoczny był głos promotora.
![image](https://github.com/iiuni/projektzapisy/assets/163182224/4786bdd0-33ee-483c-a16c-08e492c492cf)
![image](https://github.com/iiuni/projektzapisy/assets/163182224/301475b9-60e7-41a0-9ccb-3ec855e735d3)

Po wprowadzeniu zmian głosowanie przez promotora nie jest już możliwe, głos nie jest widoczny oraz nie przychodzą powiadomienia
![image](https://github.com/iiuni/projektzapisy/assets/163182224/0f0c8614-3353-4571-b251-f437f5ec6754)

Dodatkowo została usunięta możliwość dodawania głosów z poziomu panelu admina, za pomocą przycisku "+ Dodaj"
![image](https://github.com/iiuni/projektzapisy/assets/163182224/51fd02dc-f650-4c8d-9fd2-3baab8f72128)
