### PR TITLE
remove duplicate objects from queryset

### DIFF
--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -45,13 +45,10 @@ class ThesesQuerySet(models.QuerySet):
     def visible(self, user):
         if user.is_staff or is_theses_board_member(user):
             return self
-        student_theses = self.filter(students__user=user)
-        return self.filter(
-            (~Q(status=ThesisStatus.BEING_EVALUATED) & ~Q(status=ThesisStatus.RETURNED_FOR_CORRECTIONS)) |
-            Q(advisor__user=user) |
-            Q(supporting_advisor__user=user) |
-            Q(id__in=student_theses))
 
+        user_theses = self.filter(Q(students__user=user) | Q(advisor__user=user) | Q(supporting_advisor__user=user))
+        return self.filter((~Q(status=ThesisStatus.BEING_EVALUATED) &
+                            ~Q(status=ThesisStatus.RETURNED_FOR_CORRECTIONS)) | Q(id__in=user_theses))
 
 class Thesis(models.Model):
     """Represents a thesis in the theses system.

--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -50,6 +50,7 @@ class ThesesQuerySet(models.QuerySet):
         return self.filter((~Q(status=ThesisStatus.BEING_EVALUATED) &
                             ~Q(status=ThesisStatus.RETURNED_FOR_CORRECTIONS)) | Q(id__in=user_theses))
 
+
 class Thesis(models.Model):
     """Represents a thesis in the theses system.
 

--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -49,7 +49,7 @@ class ThesesQuerySet(models.QuerySet):
             (~Q(status=ThesisStatus.BEING_EVALUATED) & ~Q(status=ThesisStatus.RETURNED_FOR_CORRECTIONS)) |
             Q(advisor__user=user) |
             Q(supporting_advisor__user=user) |
-            Q(students__user=user))
+            Q(students__user=user)).distinct()
 
 
 class Thesis(models.Model):

--- a/zapisy/apps/theses/models.py
+++ b/zapisy/apps/theses/models.py
@@ -45,11 +45,12 @@ class ThesesQuerySet(models.QuerySet):
     def visible(self, user):
         if user.is_staff or is_theses_board_member(user):
             return self
+        student_theses = self.filter(students__user=user)
         return self.filter(
             (~Q(status=ThesisStatus.BEING_EVALUATED) & ~Q(status=ThesisStatus.RETURNED_FOR_CORRECTIONS)) |
             Q(advisor__user=user) |
             Q(supporting_advisor__user=user) |
-            Q(students__user=user)).distinct()
+            Q(id__in=student_theses))
 
 
 class Thesis(models.Model):


### PR DESCRIPTION
Problem wynikał z dodania do funkcji ```ThesesQuerySet.visible``` warunku ```Q(students__user=user)```. Ten warunek jest potrzebny, aby wyświetlić pracę dyplomową osobom, które powinny ją zobaczyć, gdy jest ona weryfikowana przez komisję lub została zwrócona do poprawek. Ponieważ pole ```students``` w modelu ```Thesis``` jest relacją m2m to mamy do czynienia ze złączeniem wielu tabel. W tym momencie otrzymujemy tyle wyników danej pracy dyplomowej ilu jest przypisanych do niej studentów. Aby rozwiązać ten problem usuwamy duplikaty z zapytania dopisując ```.distinct()``` do zapytania.