### PR TITLE
poprawienie definicji typu Notification w celu zapewnienia weryfikacji typów

### DIFF
--- a/zapisy/apps/notifications/assets/components/Widget.vue
+++ b/zapisy/apps/notifications/assets/components/Widget.vue
@@ -31,7 +31,12 @@ const notificationScheme = z
 
 const notificationSchemeArray = z.array(notificationScheme);
 
-type Notification = z.infer<typeof notificationScheme>;
+type Notification = {
+  id: string;
+  description: string;
+  issuedOn: string;
+  target: string;
+};
 
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
@@ -132,7 +137,7 @@ export default class NotificationsComponent extends Vue {
               <button
                 type="button"
                 class="btn-close"
-                @click="deleteOne(elem.id)"
+                @click="deleteOne(parseInt(elem.id))"
               ></button>
             </div>
             <a :href="elem.target" class="toast-link">


### PR DESCRIPTION
typ _Notification_ zdefiniowany w sposób następujący
`type Notification = z.infer<typeof notificationScheme>;`
nie zapewniał sprawdzania typów. Przykładowo, dla zmiennej _elem_, typu _Notification_, można było wywołać `deleteOne(elem.id)` mimo że funkcja _deleteOne_ przyjmuje argument typu _number,_ a `elem.id` jest typu _string_.
Dzięki nowej definicji typu _Notification_ sprawdzanie typów działa już dobrze.