### PR TITLE
1448 kolumny rownej szerokosci

### DIFF
--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -253,6 +253,11 @@ colgroup col.table-info-type {
   white-space: nowrap;
 }
 
+@media (max-width: 992px){
+  #table-info th {
+    white-space: normal;
+  }  
+}
 
 // Required field marker in forms.
 .asteriskField {

--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -244,10 +244,6 @@ div.loginbox {
   }
 }
 
-colgroup col.table-info-type {
-  background-color: #f9f9f9;
-}
-
 colgroup col.table-info-offer {
   width: 1%;
 }

--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -246,7 +246,13 @@ div.loginbox {
 
 colgroup col.table-info-type {
   background-color: #f9f9f9;
+  width: 1%;
 }
+
+#table-info th {
+  white-space: nowrap;
+}
+
 
 // Required field marker in forms.
 .asteriskField {

--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -253,10 +253,10 @@ colgroup col.table-info-type {
   white-space: nowrap;
 }
 
-@media (max-width: 992px){
+@media (max-width: 992px) {
   #table-info th {
     white-space: normal;
-  }  
+  }
 }
 
 // Required field marker in forms.

--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -254,8 +254,8 @@ colgroup col.table-info-offer {
 }
 
 @include media-breakpoint-down(lg) {
-  #table-offer th {
-    white-space: normal;
+  .table-offer th {
+    white-space: wrap;
   }
 }
 

--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -170,7 +170,7 @@ div.top .topbar .inline-inputs label {
 }
 
 #sidebar {
-  @media (max-width: 992px) {
+  @include media-breakpoint-down(lg) {
     #sidebar-inner {
       /* :after will position itself against nearest positioned parent, so we
        * need to ensure that it will be this sidebar */
@@ -203,7 +203,7 @@ div.top .topbar .inline-inputs label {
       text-align: center;
     }
   }
-  @media (min-width: 992px) {
+  @include media-breakpoint-up(lg) {
     #fold-toggler {
       display: none;
     }
@@ -246,15 +246,19 @@ div.loginbox {
 
 colgroup col.table-info-type {
   background-color: #f9f9f9;
+}
+
+colgroup col.table-info-offer {
   width: 1%;
 }
 
-#table-info th {
+.table-offer th {
   white-space: nowrap;
+  background-color: #f9f9f9;
 }
 
-@media (max-width: 992px) {
-  #table-info th {
+@include media-breakpoint-down(lg) {
+  #table-offer th {
     white-space: normal;
   }
 }
@@ -275,7 +279,7 @@ colgroup col.table-info-type {
     color: var(--bs-dark);
     font-style: italic;
     display: block;
-    @media (min-width: 992px) {
+    @include media-breakpoint-up(lg) {
       float: right;
     }
   }

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -15,9 +15,9 @@
     </div>
 </div>
 
-<table class="table table-bordered table-md-responsive" id="table-info">
+<table class="table table-bordered table-md-responsive table-offer" id="table-info">
     <colgroup>
-        <col class="table-info-type"></col>
+        <col class="table-info-type table-info-offer"></col>
     </colgroup>
     <tbody>
         <tr>

--- a/zapisy/apps/offer/proposal/templates/proposal/proposal_info.html
+++ b/zapisy/apps/offer/proposal/templates/proposal/proposal_info.html
@@ -2,7 +2,7 @@
 
 <table class="table table-bordered table-md-responsive d-print-none table-offer" id="table-info">
     <colgroup>
-        <col class="table-info-type table-what table-info-offer"></col>
+        <col class="table-info-type table-info-offer"></col>
     </colgroup>
     <tbody>
         <tr>

--- a/zapisy/apps/offer/proposal/templates/proposal/proposal_info.html
+++ b/zapisy/apps/offer/proposal/templates/proposal/proposal_info.html
@@ -1,8 +1,8 @@
 {% load filters %}
 
-<table class="table table-bordered table-md-responsive d-print-none" id="table-info">
+<table class="table table-bordered table-md-responsive d-print-none table-offer" id="table-info">
     <colgroup>
-        <col class="table-info-type"></col>
+        <col class="table-info-type table-what table-info-offer"></col>
     </colgroup>
     <tbody>
         <tr>


### PR DESCRIPTION
Dodałam stylowanie tak aby ta pierwsza kolumna tabelki była jak najmniejsza w zależności od zawartości pól tej kolumny tzn. w tym przypadku gdzie nadłuższy napis to "Grupy efektów kształcenia" wyglądają tak:
![Screenshot from 2024-11-05 14-12-55](https://github.com/user-attachments/assets/e8f107be-e3ed-4910-acec-8afd354abc37)
![Screenshot from 2024-11-05 14-14-16](https://github.com/user-attachments/assets/7ff6de94-a392-4097-8525-54fe082670cb)
Jednak gdy jakaś tabela nie zawiera tego pola to automatycznie dostosowuje się do innego najdłuższego napisu:
![Screenshot from 2024-11-05 14-14-24](https://github.com/user-attachments/assets/f85dfb21-20c8-42d9-be8f-3f8802691aa0)
Dodałam również @media aby na małych ekranach to załamywanie powróciło.
Jedno co zauważyłam to w stylowaniu colgroup col.table-info-type background-color nie jest właściwie zczytywany (prawdopodobnie przez stylowanie z pliku html). Kolor na stronie jest biały a w wersji produkcyjnej jest szary. Nie wiem czy to było zamierzone działanie, jeżeli nie to mogę wrzucić poprawkę.