### PR TITLE
Domyślna wartość komponentu CourseFilter

### DIFF
--- a/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
+++ b/zapisy/apps/offer/proposal/assets/components/CourseFilter.vue
@@ -64,6 +64,21 @@ export default Vue.extend({
       { value: "IN_VOTE", label: "poddany pod głosowanie" },
       { value: "WITHDRAWN", label: "wycofany z oferty" },
     ];
+
+    // Property "manual" signifies that from this point on
+    // changes in filters are supposed to persist through page refreshes.
+    const url = new URL(window.location.href);
+    if (!url.searchParams.has("manual")) {
+      // Delete previous parameters
+      const keys = url.searchParams.keys();
+      for (const key of keys) {
+        url.searchParams.delete(key);
+      }
+      // Set the default parameters
+      url.searchParams.set("status", "IN_OFFER,IN_VOTE");
+      url.searchParams.append("manual", "1");
+    }
+    window.history.replaceState(null, "", url.toString());
   },
   mounted: function () {
     // Extract filterable properties names from the template.


### PR DESCRIPTION
Komponent CourseFilter na odpowiedniej stronie ma teraz ustawioną wartość domyślną, aby na początku pokazywał jedynie kursy w ofercie i poddane pod głosowanie. Jednocześnie możliwość zachowania stanu filtrów przy odświeżaniu strony została zachowana.