### PR TITLE
add class so the styling will be overriden

### DIFF
--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -244,7 +244,7 @@ div.loginbox {
   }
 }
 
-colgroup col.table-info-type {
+#table-info th {
   background-color: #f9f9f9;
 }
 

--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -244,19 +244,17 @@ div.loginbox {
   }
 }
 
-.tableInfo tr th {
+.table-infobox tr th {
   background-color: #f9f9f9;
 }
 
-.table-offer th {
-  width: 1%;
-  white-space: nowrap;
-}
+@include media-breakpoint-up(lg) {
+  .table-infobox th {
+    white-space: nowrap;
+  }
 
-@include media-breakpoint-down(lg) {
-  .table-offer th {
-    width: auto;
-    white-space: wrap;
+  colgroup col.header-column {
+    width: 1%;
   }
 }
 

--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -244,7 +244,7 @@ div.loginbox {
   }
 }
 
-.table-infobox tr th {
+.table-infobox th {
   background-color: #f9f9f9;
 }
 

--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -248,6 +248,18 @@ div.loginbox {
   background-color: #f9f9f9;
 }
 
+.table-offer th{
+  width: 1%;
+  white-space: nowrap;
+}
+
+@include media-breakpoint-down(lg){
+  .table-offer th{
+    width: auto;
+    white-space: wrap;
+  }
+}
+
 // Required field marker in forms.
 .asteriskField {
   padding-left: 0.25em;

--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -248,13 +248,13 @@ div.loginbox {
   background-color: #f9f9f9;
 }
 
-.table-offer th{
+.table-offer th {
   width: 1%;
   white-space: nowrap;
 }
 
-@include media-breakpoint-down(lg){
-  .table-offer th{
+@include media-breakpoint-down(lg) {
+  .table-offer th {
     width: auto;
     white-space: wrap;
   }

--- a/zapisy/apps/common/assets/main/index.scss
+++ b/zapisy/apps/common/assets/main/index.scss
@@ -244,7 +244,7 @@ div.loginbox {
   }
 }
 
-#table-info th {
+.tableInfo tr th {
   background-color: #f9f9f9;
 }
 

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -15,7 +15,7 @@
     </div>
 </div>
 
-<table class="table table-bordered table-md-responsive tableInfo">
+<table class="table table-bordered table-md-responsive tableInfo table-offer">
     <colgroup>
         <col class="table-info-type"></col>
     </colgroup>

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -15,7 +15,7 @@
     </div>
 </div>
 
-<table class="table table-bordered table-md-responsive" id="table-info">
+<table class="table table-bordered table-md-responsive tableInfo">
     <colgroup>
         <col class="table-info-type"></col>
     </colgroup>

--- a/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
+++ b/zapisy/apps/enrollment/courses/templates/courses/course_parts/course_head.html
@@ -15,9 +15,9 @@
     </div>
 </div>
 
-<table class="table table-bordered table-md-responsive tableInfo table-offer">
+<table class="table table-bordered table-md-responsive table-infobox">
     <colgroup>
-        <col class="table-info-type"></col>
+        <col class="header-column"></col>
     </colgroup>
     <tbody>
         <tr>

--- a/zapisy/apps/offer/proposal/templates/proposal/proposal_info.html
+++ b/zapisy/apps/offer/proposal/templates/proposal/proposal_info.html
@@ -1,6 +1,6 @@
 {% load filters %}
 
-<table class="table table-bordered table-md-responsive d-print-none" id="table-info">
+<table class="table table-bordered table-md-responsive d-print-none tableInfo">
     <colgroup>
         <col class="table-info-type"></col>
     </colgroup>

--- a/zapisy/apps/offer/proposal/templates/proposal/proposal_info.html
+++ b/zapisy/apps/offer/proposal/templates/proposal/proposal_info.html
@@ -1,6 +1,6 @@
 {% load filters %}
 
-<table class="table table-bordered table-md-responsive d-print-none tableInfo">
+<table class="table table-bordered table-md-responsive d-print-none tableInfo table-offer">
     <colgroup>
         <col class="table-info-type"></col>
     </colgroup>

--- a/zapisy/apps/offer/proposal/templates/proposal/proposal_info.html
+++ b/zapisy/apps/offer/proposal/templates/proposal/proposal_info.html
@@ -1,8 +1,8 @@
 {% load filters %}
 
-<table class="table table-bordered table-md-responsive d-print-none tableInfo table-offer">
+<table class="table table-bordered table-md-responsive d-print-none table-infobox">
     <colgroup>
-        <col class="table-info-type"></col>
+        <col class="header-column"></col>
     </colgroup>
     <tbody>
         <tr>

--- a/zapisy/apps/theses/templates/theses/thesis.html
+++ b/zapisy/apps/theses/templates/theses/thesis.html
@@ -53,13 +53,13 @@
             {% endif %}
         </div>
     </div>
-    <table class="table table-bordered table-md-responsive d-print-none tableInfo">
+    <table class="table table-bordered table-md-responsive d-print-none tableInfo table-offer">
     <colgroup>
         <col class="table-info-type"></col>
     </colgroup>
     <tbody>
         <tr>
-            <th scope="row" style="width: 50%">Typ</th>
+            <th scope="row">Typ</th>
             <td>
                 {{ thesis.get_kind_display }}
             </td>

--- a/zapisy/apps/theses/templates/theses/thesis.html
+++ b/zapisy/apps/theses/templates/theses/thesis.html
@@ -53,7 +53,7 @@
             {% endif %}
         </div>
     </div>
-    <table class="table table-bordered table-md-responsive d-print-none" id="table-info">
+    <table class="table table-bordered table-md-responsive d-print-none tableInfo">
     <colgroup>
         <col class="table-info-type"></col>
     </colgroup>

--- a/zapisy/apps/theses/templates/theses/thesis.html
+++ b/zapisy/apps/theses/templates/theses/thesis.html
@@ -53,9 +53,9 @@
             {% endif %}
         </div>
     </div>
-    <table class="table table-bordered table-md-responsive d-print-none tableInfo table-offer">
+    <table class="table table-bordered table-md-responsive d-print-none table-infobox">
     <colgroup>
-        <col class="table-info-type"></col>
+        <col class="header-column"></col>
     </colgroup>
     <tbody>
         <tr>

--- a/zapisy/apps/users/templates/users/employee_profile_contents.html
+++ b/zapisy/apps/users/templates/users/employee_profile_contents.html
@@ -2,7 +2,7 @@
 
 <div id="employee-profile">
 	<h3>{{employee.get_full_name}}</h3>
-	<table class="table table-condensed">
+	<table class="table table-condensed" id="table-info">
 		<colgroup>
 			<col class="table-info-type"></col>
 			<col></col>

--- a/zapisy/apps/users/templates/users/employee_profile_contents.html
+++ b/zapisy/apps/users/templates/users/employee_profile_contents.html
@@ -2,9 +2,9 @@
 
 <div id="employee-profile">
 	<h3>{{employee.get_full_name}}</h3>
-	<table class="table table-condensed tableInfo">
+	<table class="table table-condensed table-infobox">
 		<colgroup>
-			<col class="table-info-type"></col>
+			<col class="header-column"></col>
 			<col></col>
 		</colgroup>
 		{% if user.is_authenticated %}

--- a/zapisy/apps/users/templates/users/employee_profile_contents.html
+++ b/zapisy/apps/users/templates/users/employee_profile_contents.html
@@ -8,7 +8,7 @@
 		</colgroup>
 		{% if user.is_authenticated %}
 			<tr>
-				<th>adres email</th>
+				<th>Adres e-mail</th>
 				<td>
 					{% if employee.user.email %}
 						<a href="mailto:{{employee.user.email}}">
@@ -21,7 +21,7 @@
 			</tr>
 		{% endif %}
 			<tr>
-				<th>strona domowa</th>
+				<th>Strona domowa</th>
 				<td>
 					{% if employee.homepage %}
 						<a href="{{employee.homepage}}">{{employee.homepage}}</a>
@@ -31,7 +31,7 @@
 				</td>
 			</tr>
 			<tr>
-				<th>pokój</th>
+				<th>Pokój</th>
 				<td>
 						{{employee.room|default_if_none:"brak danych"}}
 				</td>

--- a/zapisy/apps/users/templates/users/employee_profile_contents.html
+++ b/zapisy/apps/users/templates/users/employee_profile_contents.html
@@ -5,7 +5,6 @@
 	<table class="table table-condensed table-infobox">
 		<colgroup>
 			<col class="header-column"></col>
-			<col></col>
 		</colgroup>
 		{% if user.is_authenticated %}
 			<tr>

--- a/zapisy/apps/users/templates/users/employee_profile_contents.html
+++ b/zapisy/apps/users/templates/users/employee_profile_contents.html
@@ -2,7 +2,7 @@
 
 <div id="employee-profile">
 	<h3>{{employee.get_full_name}}</h3>
-	<table class="table table-condensed" id="table-info">
+	<table class="table table-condensed tableInfo">
 		<colgroup>
 			<col class="table-info-type"></col>
 			<col></col>

--- a/zapisy/apps/users/templates/users/my_profile.html
+++ b/zapisy/apps/users/templates/users/my_profile.html
@@ -10,7 +10,7 @@
 {% block all-content %}
     <div class="mb-5">
         <h2>Moje dane</h2>
-        <table class="table table-condensed">
+        <table class="table table-condensed" id="table-info">
             <colgroup>
                 <col class="table-info-type"></col>
                 <col></col>

--- a/zapisy/apps/users/templates/users/my_profile.html
+++ b/zapisy/apps/users/templates/users/my_profile.html
@@ -74,7 +74,7 @@
     {% if user.student %}
     <div class="mb-5">
         <h2>Moje studia</h2>
-        <table class="table table-condensed">
+        <table class="table table-condensed" id="table-info">
             <colgroup>
                 <col class="table-info-type"></col>
                 <col></col>
@@ -104,7 +104,7 @@
 
     <div class="mb-5">
         <h2>Terminy</h2>
-        <table class="table table-condensed">
+        <table class="table table-condensed" id="table-info">
             <colgroup>
                 <col class="table-info-type"></col>
                 <col></col>
@@ -172,7 +172,7 @@
     {% if semesters_participated_in_grade %}
         <div class="mb-5">
             <h2>Udział w Ocenie zajęć</h2>
-            <table class="table table-condensed">
+            <table class="table table-condensed" id="table-info">
                 <colgroup>
                     <col class="table-info-type"></col>
                     <col></col>

--- a/zapisy/apps/users/templates/users/my_profile.html
+++ b/zapisy/apps/users/templates/users/my_profile.html
@@ -10,9 +10,9 @@
 {% block all-content %}
     <div class="mb-5">
         <h2>Moje dane</h2>
-        <table class="table table-condensed tableInfo table-offer">
+        <table class="table table-condensed table-infobox">
             <colgroup>
-                <col class="table-info-type"></col>
+                <col class="header-column"></col>
                 <col></col>
             </colgroup>
             <tr>
@@ -74,9 +74,9 @@
     {% if user.student %}
     <div class="mb-5">
         <h2>Moje studia</h2>
-        <table class="table table-condensed tableInfo table-offer">
+        <table class="table table-condensed table-infobox">
             <colgroup>
-                <col class="table-info-type"></col>
+                <col class="header-column"></col>
                 <col></col>
             </colgroup>
             <tr>
@@ -104,9 +104,9 @@
 
     <div class="mb-5">
         <h2>Terminy</h2>
-        <table class="table table-condensed tableInfo table-offer">
+        <table class="table table-condensed table-infobox">
             <colgroup>
-                <col class="table-info-type"></col>
+                <col class="header-column"></col>
                 <col></col>
             </colgroup>
             {% with dateFormatStr="l j E G:i" %}
@@ -172,9 +172,9 @@
     {% if semesters_participated_in_grade %}
         <div class="mb-5">
             <h2>Udział w Ocenie zajęć</h2>
-            <table class="table table-condensed tableInfo table-offer">
+            <table class="table table-condensed table-infobox">
                 <colgroup>
-                    <col class="table-info-type"></col>
+                    <col class="header-column"></col>
                     <col></col>
                 </colgroup>
                 {% for semester in semesters_participated_in_grade %}

--- a/zapisy/apps/users/templates/users/my_profile.html
+++ b/zapisy/apps/users/templates/users/my_profile.html
@@ -13,7 +13,6 @@
         <table class="table table-condensed table-infobox">
             <colgroup>
                 <col class="header-column"></col>
-                <col></col>
             </colgroup>
             <tr>
                 <th>login</th>
@@ -77,7 +76,6 @@
         <table class="table table-condensed table-infobox">
             <colgroup>
                 <col class="header-column"></col>
-                <col></col>
             </colgroup>
             <tr>
                 <th>Punkty ECTS uzyskane do końca poprzedniego semestru</th>
@@ -107,7 +105,6 @@
         <table class="table table-condensed table-infobox">
             <colgroup>
                 <col class="header-column"></col>
-                <col></col>
             </colgroup>
             {% with dateFormatStr="l j E G:i" %}
             <tr>
@@ -175,7 +172,6 @@
             <table class="table table-condensed table-infobox">
                 <colgroup>
                     <col class="header-column"></col>
-                    <col></col>
                 </colgroup>
                 {% for semester in semesters_participated_in_grade %}
                     <tr>

--- a/zapisy/apps/users/templates/users/my_profile.html
+++ b/zapisy/apps/users/templates/users/my_profile.html
@@ -15,11 +15,11 @@
                 <col class="header-column"></col>
             </colgroup>
             <tr>
-                <th>login</th>
+                <th>Login</th>
                 <td>{{ request.user.username }}</td>
             </tr>
             <tr>
-                <th>email</th>
+                <th>Adres e-mail</th>
                 <td>{{ request.user.email }}</td>
             </tr>
             {% if user.student %}
@@ -41,19 +41,19 @@
             {% endif %}
             {% if user.employee %}
                 <tr>
-                    <th>pokój</th>
+                    <th>Pokój</th>
                     <td>{{ request.user.employee.room }}</td>
                 </tr>
                 <tr>
-                    <th>strona domowa</th>
+                    <th>Strona domowa</th>
                     <td><a href="{{ homepage }}">{{ request.user.employee.homepage|default:"" }}</a></td>
                 </tr>
                 <tr>
-                    <th>tytuł naukowy</th>
+                    <th>Tytuł naukowy</th>
                     <td>{{ request.user.employee.title }}</td>
                 </tr>
                 <tr>
-                    <th>konsultacje</th>
+                    <th>Konsultacje</th>
                     <td>
                         {{ user.employee.consultations }}
                     </td>

--- a/zapisy/apps/users/templates/users/my_profile.html
+++ b/zapisy/apps/users/templates/users/my_profile.html
@@ -10,7 +10,7 @@
 {% block all-content %}
     <div class="mb-5">
         <h2>Moje dane</h2>
-        <table class="table table-condensed tableInfo">
+        <table class="table table-condensed tableInfo table-offer">
             <colgroup>
                 <col class="table-info-type"></col>
                 <col></col>
@@ -74,7 +74,7 @@
     {% if user.student %}
     <div class="mb-5">
         <h2>Moje studia</h2>
-        <table class="table table-condensed tableInfo">
+        <table class="table table-condensed tableInfo table-offer">
             <colgroup>
                 <col class="table-info-type"></col>
                 <col></col>
@@ -104,7 +104,7 @@
 
     <div class="mb-5">
         <h2>Terminy</h2>
-        <table class="table table-condensed tableInfo">
+        <table class="table table-condensed tableInfo table-offer">
             <colgroup>
                 <col class="table-info-type"></col>
                 <col></col>
@@ -172,7 +172,7 @@
     {% if semesters_participated_in_grade %}
         <div class="mb-5">
             <h2>Udział w Ocenie zajęć</h2>
-            <table class="table table-condensed tableInfo">
+            <table class="table table-condensed tableInfo table-offer">
                 <colgroup>
                     <col class="table-info-type"></col>
                     <col></col>

--- a/zapisy/apps/users/templates/users/my_profile.html
+++ b/zapisy/apps/users/templates/users/my_profile.html
@@ -10,7 +10,7 @@
 {% block all-content %}
     <div class="mb-5">
         <h2>Moje dane</h2>
-        <table class="table table-condensed" id="table-info">
+        <table class="table table-condensed tableInfo">
             <colgroup>
                 <col class="table-info-type"></col>
                 <col></col>
@@ -74,7 +74,7 @@
     {% if user.student %}
     <div class="mb-5">
         <h2>Moje studia</h2>
-        <table class="table table-condensed" id="table-info">
+        <table class="table table-condensed tableInfo">
             <colgroup>
                 <col class="table-info-type"></col>
                 <col></col>
@@ -104,7 +104,7 @@
 
     <div class="mb-5">
         <h2>Terminy</h2>
-        <table class="table table-condensed" id="table-info">
+        <table class="table table-condensed tableInfo">
             <colgroup>
                 <col class="table-info-type"></col>
                 <col></col>
@@ -172,7 +172,7 @@
     {% if semesters_participated_in_grade %}
         <div class="mb-5">
             <h2>Udział w Ocenie zajęć</h2>
-            <table class="table table-condensed" id="table-info">
+            <table class="table table-condensed tableInfo">
                 <colgroup>
                     <col class="table-info-type"></col>
                     <col></col>

--- a/zapisy/apps/users/templates/users/student_profile_contents.html
+++ b/zapisy/apps/users/templates/users/student_profile_contents.html
@@ -2,7 +2,7 @@
 
 <div id="student-profile">
 	<h3 class="subheader">{{student.get_full_name}}</h3>
-	<table class="table table-condensed">
+	<table class="table table-condensed" id="table-info">
 			<colgroup>
 				<col class="table-info-type"></col>
 				<col></col>

--- a/zapisy/apps/users/templates/users/student_profile_contents.html
+++ b/zapisy/apps/users/templates/users/student_profile_contents.html
@@ -2,9 +2,9 @@
 
 <div id="student-profile">
 	<h3 class="subheader">{{student.get_full_name}}</h3>
-	<table class="table table-condensed tableInfo">
+	<table class="table table-condensed table-infobox">
 			<colgroup>
-				<col class="table-info-type"></col>
+				<col class="header-column"></col>
 				<col></col>
 			</colgroup>
 		<tr>

--- a/zapisy/apps/users/templates/users/student_profile_contents.html
+++ b/zapisy/apps/users/templates/users/student_profile_contents.html
@@ -2,7 +2,7 @@
 
 <div id="student-profile">
 	<h3 class="subheader">{{student.get_full_name}}</h3>
-	<table class="table table-condensed" id="table-info">
+	<table class="table table-condensed tableInfo">
 			<colgroup>
 				<col class="table-info-type"></col>
 				<col></col>

--- a/zapisy/apps/users/templates/users/student_profile_contents.html
+++ b/zapisy/apps/users/templates/users/student_profile_contents.html
@@ -5,7 +5,6 @@
 	<table class="table table-condensed table-infobox">
 			<colgroup>
 				<col class="header-column"></col>
-				<col></col>
 			</colgroup>
 		<tr>
 			<th>Adres email</th>

--- a/zapisy/apps/users/templates/users/student_profile_contents.html
+++ b/zapisy/apps/users/templates/users/student_profile_contents.html
@@ -7,7 +7,7 @@
 				<col class="header-column"></col>
 			</colgroup>
 		<tr>
-			<th>Adres email</th>
+			<th>Adres e-mail</th>
 			<td>
 				{% if student.user.email %}
 					<a href="mailto:{{student.user.email}}">


### PR DESCRIPTION
Problem leżał w dwóch rzeczach: 

- bootstrap w .table ma swoje wlasne zmienne i istnieje taka zmienna jak **--bs-table-bg** która koloruje wszystkie komórki tabeli na biało
- colgroup i col to już w ogóle jakiś inny świat. Wspierają tylko border, background, width i visibility i w dodatku atrybut background ustawi kolor tylko wtedy gdy komórki mają transparentne tło.  
![image](https://github.com/user-attachments/assets/ef450b0f-8c14-4ce8-b782-cd797876d9ad)

Przez mieszankę tych dwóch punktów stylowanie które było wcześniej i opierało się tylko na colgroup i col było bezużyteczne bo było przykrywane przez bootstrap. Dlatego dodałam ten identyfikator (identyfikator ma wyższą specyfikacje od klasy w css przez co nadpisze stylowanie bootstrapa) który występował wcześniej w kodzie do reszty plików .html w którym ten kolor przestał działać i dodałam kolor na stylowanie komórek th. Można też nadpisać ten kolor poprzez użycie klasy .table th ale to chyba by za dużo namieszało bo to jednak klasa bootstrapa