### PR TITLE
Fix exam room reservation permissions

### DIFF
--- a/zapisy/apps/schedule/models/event.py
+++ b/zapisy/apps/schedule/models/event.py
@@ -93,7 +93,7 @@ class Event(models.Model):
 
             # students can only add generic events that have to be accepted first
 
-            if self.author.student and not self.author.has_perm(
+            if not self.author.employee and not self.author.has_perm(
                     'schedule.manage_events'):
                 if self.type != Event.TYPE_GENERIC:
                     raise ValidationError(


### PR DESCRIPTION
Currently if someone have both tag `employee` and `student`, then such person can not reserve room for the exam. This PR should fix the condition for that.