### PR TITLE
#1748 - upgrade do Ubuntu 22.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@
 # you're doing.
 Vagrant.configure(2) do |config|
   config.ssh.shell = "bash"
-  config.vm.box = "test"
+  config.vm.box = "ubuntu/jammy64"
 
   # Installs ansible as it is not yet provided for focal.
   # https://github.com/ansible/ansible/issues/69203
@@ -17,6 +17,7 @@ Vagrant.configure(2) do |config|
   SHELL
   config.vm.provision "ansible_local" do |ansible|
     ansible.playbook = "infra/playbooks/dev/playbook.yml"
+    ansible.compatibility_mode = "2.0"
   end
   config.vm.network :forwarded_port, guest: 80, host: 8001
   config.vm.network :forwarded_port, guest: 8000, host: 8000

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
-Vagrant.configure(2) do |config|
+Vagrant.configure("2") do |config|
   config.ssh.shell = "bash"
   config.vm.box = "ubuntu/jammy64"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@
 # you're doing.
 Vagrant.configure(2) do |config|
   config.ssh.shell = "bash"
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "test"
 
   # Installs ansible as it is not yet provided for focal.
   # https://github.com/ansible/ansible/issues/69203

--- a/infra/hosts/Vagrantfile
+++ b/infra/hosts/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "test"
+  config.vm.box = "ubuntu/jammy64"
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.

--- a/infra/hosts/Vagrantfile
+++ b/infra/hosts/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "test"
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.

--- a/infra/playbooks/configure.yml
+++ b/infra/playbooks/configure.yml
@@ -53,6 +53,12 @@
         group: "{{ deploy_user }}"
         create_home: yes
 
+    - name: Ensure deploy_user's home directory has correct permissions
+      become: yes
+      file:
+        path: "/home/{{ deploy_user }}"
+        mode: "0755"
+
     - name: Generate Postgres password
       set_fact:
         APP_DB_PASS: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"

--- a/infra/playbooks/deploy.yml
+++ b/infra/playbooks/deploy.yml
@@ -131,6 +131,8 @@
         keep_releases: 2
 
     - name: Get revision
+      become: yes
+      become_user: "{{ deploy_user }}"
       shell: git rev-parse HEAD
       register: git_rev
       args:

--- a/infra/playbooks/dev/playbook.yml
+++ b/infra/playbooks/dev/playbook.yml
@@ -6,6 +6,10 @@
     ansible_python_interpreter: "/usr/bin/python3"
 
   tasks:
+    - name: Change permissions to /home/vagrant
+      ansible.builtin.file:
+        path: /home/vagrant
+        mode: "775"
 
     # https://github.com/ansible/ansible/issues/25414#issuecomment-440549135
     - name: Wait for any possibly running unattended upgrade to finish
@@ -45,7 +49,10 @@
       vars:
         ansible_python_interpreter: "{{ PYTHON }}"
       pip:
-        name: pip
+        name: 
+          - pip
+          - wheel
+          - setuptools 
         state: latest
         virtualenv: ~/env3
         virtualenv_command: "{{ PYTHON }} -m venv"

--- a/infra/playbooks/dev/playbook.yml
+++ b/infra/playbooks/dev/playbook.yml
@@ -6,7 +6,7 @@
     ansible_python_interpreter: "/usr/bin/python3"
 
   tasks:
-    - name: Change permissions to /home/vagrant
+    - name: Ensure /home/vagrant has correct permissions
       ansible.builtin.file:
         path: /home/vagrant
         mode: "775"

--- a/infra/playbooks/dev/postgres.yml
+++ b/infra/playbooks/dev/postgres.yml
@@ -5,7 +5,7 @@
     APP_DB_USER: fereol
     APP_DB_PASS: fereolpass
     APP_DB_NAME: fereol
-    PG_VERSION: 12
+    PG_VERSION: 14
     PYTHON: "/home/vagrant/env3/bin/python3"
     ansible_python_interpreter: "/usr/bin/python3"
 

--- a/infra/playbooks/newrelic.yml
+++ b/infra/playbooks/newrelic.yml
@@ -6,7 +6,7 @@
 
 - name: Add New Relic APT Repository
   apt_repository:
-    repo: deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt bionic main
+    repo: deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt jammy main
     state: present
     filename: newrelic
 

--- a/zapisy/requirements.common.txt
+++ b/zapisy/requirements.common.txt
@@ -19,7 +19,7 @@ prompt-toolkit==3.0.50
 ipython==7.34.0
 pycryptodome==3.21.0
 rollbar==0.16.3
-newrelic==5.24.0.153
+newrelic
 gunicorn==20.1.0
 python-dateutil==2.9.0.post0
 python-memcached==1.62


### PR DESCRIPTION
Podniesiono wersję Ubuntu do 22.04 (`jammy`). Przy okazji podniesiono parę innych usług, których podniesienie było wymagane w związku z tym podbiciem wersji OS (szczegóły w diffie) i wykonano parę innych, drobnych zmian, które same tłumaczą się lepiej niż mógłby je wytłumaczyć ten opis. _Kwestia poboczna_, jaką był warning dot. nieznanej wersji Ansible. została zażegnana - wynikało to ze zmiany formatu stringa `ansible --version` w nowszych wersjach Ansible.

Opis zmian:
* podniesiono wersję Ubuntu do 22.04;
* podniesiono wersję PostgreSQL w środowisku _deweloperskim_ do 14 (na życzenie Ubuntu 22.04); w środowisku _produkcyjnym_ to dzieje się samoistnie (sic!));
* wykonano drobną przebudowę playbooków Ansible konfigurujących środowisko deweloperskie (szczegóły w diffie);
* poprawiono playbook do deployu środowiska produkcyjnego (szczegóły w diffie).