### PR TITLE
wydarzenie niezaakceptowne nie wyswietla sie w kalendarzu

### DIFF
--- a/zapisy/apps/schedule/views.py
+++ b/zapisy/apps/schedule/views.py
@@ -334,7 +334,7 @@ class EventsTermsAjaxView(FullCalendarView):
 
     def get_queryset(self):
         queryset = super(EventsTermsAjaxView, self).get_queryset()
-        queryset = queryset.filter(event__type='2', event__visible=True)
+        queryset = queryset.filter(event__type='2', event__visible=True, event__status=Event.STATUS_ACCEPTED)
         return queryset
 
 


### PR DESCRIPTION
Dodałem dodatkowy warunek sprawdzajacy czy dane wydarzenie zostalo juz zaakceptowane przy rozstrzyganiu czy powinno sie wyswietlac w kalendarzu.

Wczesniej dowolny uzytkownik mogl kliknac w wydarzenie otrzymujac blad 404